### PR TITLE
Fix ci.jenkins.io OOM: reduce forkCount to 1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 buildPlugin(
-  forkCount: '1C',
+  forkCount: '1',
   useContainerAgent: true,
   configurations: [
     [platform: 'linux', jdk: 17],


### PR DESCRIPTION
`AiAgentRunActionTest` crashes with exit code 143 (OOM kill / SIGTERM) on ci.jenkins.io container agents with 768MB heap when running multiple Surefire forks in parallel (`forkCount=1C`).

Reducing to a single fork (`forkCount=1`) so all tests run sequentially in one JVM, which should stay within the memory budget.