### PR TITLE
Fix javadoc error on JDK 21

### DIFF
--- a/src/main/java/io/jenkins/plugins/aiagentjob/claudecode/ClaudeCodeLogFormat.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/claudecode/ClaudeCodeLogFormat.java
@@ -11,8 +11,9 @@ import net.sf.json.JSONObject;
  * Format-specific log classification for Claude Code stream-json output. Handles content arrays
  * (tool_use, tool_result, thinking, text) and stream_event deltas.
  *
- * <p>Used by both {@link ClaudeCodeAgentHandler} and {@link GeminiCliAgentHandler} since they share
- * the same stream-json format.
+ * <p>Used by both {@link ClaudeCodeAgentHandler} and {@link
+ * io.jenkins.plugins.aiagentjob.geminicli.GeminiCliAgentHandler GeminiCliAgentHandler} since they
+ * share the same stream-json format.
  */
 public final class ClaudeCodeLogFormat implements AiAgentLogFormat {
 


### PR DESCRIPTION
`ClaudeCodeLogFormat` referenced `GeminiCliAgentHandler` in a `@link` tag without a fully qualified name. This causes `javadoc:jar` to fail on ci.jenkins.io (JDK 21 has stricter javadoc linting).

Fixed by using the FQN in the `@link` tag.

This was the root cause of the ci.jenkins.io `Jenkins` check failing on main, which blocks the CD release workflow.