### PR TITLE
Update dependencies: GH Actions + Jenkins BOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: Upload coverage report
         if: matrix.java == 21
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: jacoco-report
           path: target/site/jacoco/
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload HPI
         if: matrix.java == 21
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ai-agent.hpi
           path: target/ai-agent.hpi

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>6146.vc53a_0edb_e986</version>
+        <version>6166.va_a_8b_5eda_8ef5</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Bumps all pending Renovate-tracked dependencies:

### GitHub Actions
| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | v4 | v6 |
| `actions/setup-java` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |

### Maven
| Dependency | Old | New |
|------------|-----|-----|
| `io.jenkins.tools.bom:bom-2.528.x` | `6146.vc53a_0edb_e986` | `6166.va_a_8b_5eda_8ef5` |

Verified locally: **180 tests pass, 0 failures.**