### PR TITLE
Fix incorrect default approval timeout in help text

### DIFF
--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-approvalTimeoutSeconds.html
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-approvalTimeoutSeconds.html
@@ -1,5 +1,5 @@
 <div>
   Maximum number of seconds to wait for an approval decision before the
   build is failed. Only used when <strong>Require manual approvals</strong>
-  is enabled. The default is 300 seconds (5 minutes).
+  is enabled. The default is 600 seconds (10 minutes).
 </div>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR fixes the help text for `Approval timeout (seconds)` in the `Run AI Agent` build step.

The UI documentation said the default timeout was `300 seconds (5 minutes)`, but the actual code default is `600 seconds (10 minutes)`. 
https://github.com/jenkinsci/ai-agent-plugin/blob/6944339dcbd7a64387a8973e287b07385f22d7b4/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentBuilder.java#L49
This change updates the help text to match the implementation so users see the correct default behavior when configuring the step.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
