### PR TITLE
Fix missing browsers.svg causing 404 on build summary page

### DIFF
--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary.jelly
@@ -10,7 +10,6 @@
 
   <div class="ai-conv">
     <h3 class="ai-conv-title">
-      <img src="${resURL}/plugin/ai-agent/browsers.svg" class="icon-md"/>
       <l:icon src="symbol-terminal" class="icon-md" />
       AI Agent Conversation
     </h3>


### PR DESCRIPTION
## Problem

`summary.jelly` references `${resURL}/plugin/ai-agent/browsers.svg` (line 13), but this file was **never included** in the plugin. Every build summary page makes a request that returns a 404, showing a broken image icon.

This was introduced in PR #1 ("Refine UI", commit `b6a9fbc`) which changed the title icon from `<l:icon src="terminal">` to an `<img>` tag pointing at `browsers.svg` + an `<l:icon src="symbol-terminal">`. The SVG file was never added to `src/main/webapp/`, so the `<img>` has been broken since the first `jenkinsci` release.

## Fix

Remove the broken `<img>` tag. The `<l:icon src="symbol-terminal" class="icon-md" />` on the next line already renders the correct terminal icon — it's the only icon actually needed.

## Testing

- Verified locally that `browsers.svg` does not exist anywhere under `src/main/`
- The remaining `<l:icon>` tag uses Jenkins core symbol rendering, which works without any additional static assets

Fixes #10