### PR TITLE
docs: update README installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Build page showing a Cursor Agent conversation with tool calls, markdown-rendere
 
 ## Installation
 
+### Option 1: Install from the Jenkins Plugin Center (Recommended)
+
+1. In Jenkins, go to **Manage Jenkins > Plugins**.
+2. Open the **Available plugins** tab.
+3. Search for `AI Agent` (plugin ID: `ai-agent`).
+4. Install the plugin and restart Jenkins if prompted.
+
+### Option 2: Offline/Manual Installation with an `.hpi` File
+
 1. Build the plugin (see [Building](#building)) or download a release `.hpi`.
 2. Go to **Manage Jenkins > Plugins > Advanced settings**.
 3. Upload the `.hpi` file under **Deploy Plugin**.


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Update README.md installation instructions to make Jenkins Plugin Center installation the recommended path for users.

Reorganize the section into two clear options:
- Option 1: Install from the Jenkins Plugin Center (Recommended)
- Option 2: Offline/Manual Installation with an .hpi File

Keep the existing offline .hpi installation flow as an alternative for manual installs.
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
