### PR TITLE
Fix broken invocation query string in build summary links

### DIFF
--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary.jelly
@@ -37,8 +37,8 @@
               <j:if test="${inv.exitCode != null}">
                 <span class="ai-meta-badge ai-meta-badge-exit-${inv.exitCode == 0 ? 'success' : 'failure'}">Exit: ${inv.exitCode}</span>
               </j:if>
-              <a href="${it.urlName}/conversation?$invocation=${inv.id}" class="jenkins-button">Open full conversation</a>
-              <a href="${it.urlName}/raw?$invocation=${inv.id}" class="jenkins-button">Raw Log</a>
+              <a href="${it.urlName}/conversation?invocation=${inv.id}" class="jenkins-button">Open full conversation</a>
+              <a href="${it.urlName}/raw?invocation=${inv.id}" class="jenkins-button">Raw Log</a>
             </span>
           </div>
 


### PR DESCRIPTION
## Summary

- `summary.jelly` built the "Open full conversation" and "Raw Log" hrefs with `?$invocation=${inv.id}` -- the stray `$` means the query param is literally named `$invocation`, which nothing reads, so both buttons always fall through to the latest invocation instead of the one on the card the user clicked.
- Drop the `$` so the param name matches the rest of the file (`invocation=${inv.id}` at lines 48-51) and the Stapler endpoints that read `request.getParameter("invocation")`.

Before: clicking the buttons on invocation #1 in a build with multiple invocations opens invocation #latest.
After: each card's buttons open its own invocation.

## Test plan

- [x] Run a freestyle or pipeline job with at least two AI agent invocations in the same build.
- [x] From the build page, click "Open full conversation" and "Raw Log" on the older invocation card and confirm the URL contains `invocation=<that-id>` and the page shows that invocation.