### PR TITLE
[core] Add disable interactive mode setting

### DIFF
--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentBuilder.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentBuilder.java
@@ -3,6 +3,7 @@ package io.jenkins.plugins.aiagentjob;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -19,12 +20,12 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+
 import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeAgentHandler;
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
+
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
+
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.AncestorInPath;
@@ -33,305 +34,314 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
 /** Build step that runs AI coding agents and can be used from freestyle and pipeline jobs. */
 public class AiAgentBuilder extends Builder implements SimpleBuildStep, AiAgentConfiguration {
-  private AiAgentTypeHandler agent = new ClaudeCodeAgentHandler();
-  private String model = "";
-  private String prompt = "";
-  private String workingDirectory = "";
-  private boolean yoloMode;
-  private boolean requireApprovals;
-  private int approvalTimeoutSeconds = 600;
-  private String commandOverride = "";
-  private String extraArgs = "";
-  private String environmentVariables = "";
-  private boolean failOnAgentError = true;
-  private String setupScript = "";
-  private String apiCredentialsId = "";
-  private String apiEnvVarName = "";
-  private boolean disableInteractive;
+    private AiAgentTypeHandler agent = new ClaudeCodeAgentHandler();
+    private String model = "";
+    private String prompt = "";
+    private String workingDirectory = "";
+    private boolean yoloMode;
+    private boolean requireApprovals;
+    private int approvalTimeoutSeconds = 600;
+    private String commandOverride = "";
+    private String extraArgs = "";
+    private String environmentVariables = "";
+    private boolean failOnAgentError = true;
+    private String setupScript = "";
+    private String apiCredentialsId = "";
+    private String apiEnvVarName = "";
+    private boolean disableInteractive;
 
-  @DataBoundConstructor
-  public AiAgentBuilder() {}
+    @DataBoundConstructor
+    public AiAgentBuilder() {}
 
-  @Override
-  public void perform(
-      Run<?, ?> run, FilePath workspace, EnvVars env, Launcher launcher, TaskListener listener)
-      throws InterruptedException, IOException {
-    AiAgentRunAction action = AiAgentRunAction.getOrCreate(run);
-    int exitCode = AiAgentExecutor.execute(run, workspace, env, launcher, listener, this, action);
-    if (exitCode != 0 && isFailOnAgentError()) {
-      listener
-          .getLogger()
-          .println("[ai-agent] Agent finished with non-zero exit code: " + exitCode);
-      throw new IOException("AI agent finished with non-zero exit code: " + exitCode);
-    }
-    if (exitCode != 0) {
-      listener
-          .getLogger()
-          .println("[ai-agent] Agent exited with code " + exitCode + ", but failure is disabled.");
-    }
-  }
-
-  @Override
-  public AiAgentTypeHandler getAgent() {
-    if (agent == null) {
-      agent = new ClaudeCodeAgentHandler();
-    }
-    return agent;
-  }
-
-  @DataBoundSetter
-  public void setAgent(AiAgentTypeHandler agent) {
-    this.agent = agent == null ? new ClaudeCodeAgentHandler() : agent;
-  }
-
-  @Override
-  public String getModel() {
-    return model;
-  }
-
-  @DataBoundSetter
-  public void setModel(String model) {
-    this.model = Util.fixNull(model);
-  }
-
-  @Override
-  public String getPrompt() {
-    return prompt;
-  }
-
-  @DataBoundSetter
-  public void setPrompt(String prompt) {
-    this.prompt = Util.fixNull(prompt);
-  }
-
-  @Override
-  public String getWorkingDirectory() {
-    return workingDirectory;
-  }
-
-  @DataBoundSetter
-  public void setWorkingDirectory(String workingDirectory) {
-    this.workingDirectory = Util.fixNull(workingDirectory);
-  }
-
-  @Override
-  public boolean isYoloMode() {
-    return yoloMode;
-  }
-
-  @DataBoundSetter
-  public void setYoloMode(boolean yoloMode) {
-    this.yoloMode = yoloMode;
-  }
-
-  @Override
-  public boolean isRequireApprovals() {
-    return requireApprovals;
-  }
-
-  @DataBoundSetter
-  public void setRequireApprovals(boolean requireApprovals) {
-    this.requireApprovals = requireApprovals;
-  }
-
-  @Override
-  public int getApprovalTimeoutSeconds() {
-    return approvalTimeoutSeconds;
-  }
-
-  @DataBoundSetter
-  public void setApprovalTimeoutSeconds(int approvalTimeoutSeconds) {
-    this.approvalTimeoutSeconds = Math.max(1, approvalTimeoutSeconds);
-  }
-
-  @Override
-  public String getCommandOverride() {
-    return commandOverride;
-  }
-
-  @DataBoundSetter
-  public void setCommandOverride(String commandOverride) {
-    this.commandOverride = normalizeCommandOverride(commandOverride);
-  }
-
-  @Override
-  public String getExtraArgs() {
-    return extraArgs;
-  }
-
-  @DataBoundSetter
-  public void setExtraArgs(String extraArgs) {
-    this.extraArgs = Util.fixNull(extraArgs);
-  }
-
-  @Override
-  public String getEnvironmentVariables() {
-    return environmentVariables;
-  }
-
-  @DataBoundSetter
-  public void setEnvironmentVariables(String environmentVariables) {
-    this.environmentVariables = Util.fixNull(environmentVariables);
-  }
-
-  @Override
-  public boolean isFailOnAgentError() {
-    return failOnAgentError;
-  }
-
-  @DataBoundSetter
-  public void setFailOnAgentError(boolean failOnAgentError) {
-    this.failOnAgentError = failOnAgentError;
-  }
-
-  @Override
-  public String getSetupScript() {
-    return setupScript;
-  }
-
-  @DataBoundSetter
-  public void setSetupScript(String setupScript) {
-    this.setupScript = Util.fixNull(setupScript);
-  }
-
-  @Override
-  public String getApiCredentialsId() {
-    return apiCredentialsId;
-  }
-
-  @DataBoundSetter
-  public void setApiCredentialsId(String apiCredentialsId) {
-    this.apiCredentialsId = Util.fixNull(apiCredentialsId);
-  }
-
-  public String getApiEnvVarName() {
-    return apiEnvVarName;
-  }
-
-  @DataBoundSetter
-  public void setApiEnvVarName(String apiEnvVarName) {
-    this.apiEnvVarName = Util.fixNull(apiEnvVarName);
-  }
-
-  @Override
-  public boolean isDisableInteractive() {
-    return disableInteractive;
-  }
-
-  @DataBoundSetter
-  public void setDisableInteractive(boolean disableInteractive) {
-    this.disableInteractive = disableInteractive;
-  }
-
-  @Override
-  public String getEffectiveApiKeyEnvVar() {
-    String custom = Util.fixEmptyAndTrim(apiEnvVarName);
-    return custom != null ? custom : getAgent().getDefaultApiKeyEnvVar();
-  }
-
-  private Object readResolve() {
-    if (agent == null) {
-      agent = new ClaudeCodeAgentHandler();
-    }
-    model = Util.fixNull(model);
-    prompt = Util.fixNull(prompt);
-    workingDirectory = Util.fixNull(workingDirectory);
-    commandOverride = normalizeCommandOverride(commandOverride);
-    extraArgs = Util.fixNull(extraArgs);
-    environmentVariables = Util.fixNull(environmentVariables);
-    setupScript = Util.fixNull(setupScript);
-    apiCredentialsId = Util.fixNull(apiCredentialsId);
-    apiEnvVarName = Util.fixNull(apiEnvVarName);
-    approvalTimeoutSeconds = Math.max(1, approvalTimeoutSeconds);
-    return this;
-  }
-
-  private static String normalizeCommandOverride(String commandOverride) {
-    return Util.fixNull(commandOverride).replaceAll("\\s*[\\r\\n]+\\s*", " ").trim();
-  }
-
-  @Extension
-  @Symbol("aiAgent")
-  public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
-    public List<Descriptor<AiAgentTypeHandler>> getAgentDescriptors() {
-      return DescriptorVisibilityFilter.apply(
-          null, Jenkins.get().getDescriptorList(AiAgentTypeHandler.class));
+    @Override
+    public void perform(
+            Run<?, ?> run,
+            FilePath workspace,
+            EnvVars env,
+            Launcher launcher,
+            TaskListener listener)
+            throws InterruptedException, IOException {
+        AiAgentRunAction action = AiAgentRunAction.getOrCreate(run);
+        int exitCode =
+                AiAgentExecutor.execute(run, workspace, env, launcher, listener, this, action);
+        if (exitCode != 0 && isFailOnAgentError()) {
+            listener.getLogger()
+                    .println("[ai-agent] Agent finished with non-zero exit code: " + exitCode);
+            throw new IOException("AI agent finished with non-zero exit code: " + exitCode);
+        }
+        if (exitCode != 0) {
+            listener.getLogger()
+                    .println(
+                            "[ai-agent] Agent exited with code "
+                                    + exitCode
+                                    + ", but failure is disabled.");
+        }
     }
 
     @Override
-    public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-      return true;
+    public AiAgentTypeHandler getAgent() {
+        if (agent == null) {
+            agent = new ClaudeCodeAgentHandler();
+        }
+        return agent;
+    }
+
+    @DataBoundSetter
+    public void setAgent(AiAgentTypeHandler agent) {
+        this.agent = agent == null ? new ClaudeCodeAgentHandler() : agent;
     }
 
     @Override
-    public String getDisplayName() {
-      return "Run AI Agent";
+    public String getModel() {
+        return model;
     }
 
-    @POST
-    public ListBoxModel doFillApiCredentialsIdItems(
-        @AncestorInPath Item item, @QueryParameter String apiCredentialsId) {
-      checkConfigurationPermission(item);
-      StandardListBoxModel result = new StandardListBoxModel();
-      return result
-          .includeEmptyValue()
-          .includeMatchingAs(
-              item instanceof hudson.model.Queue.Task
-                  ? ((hudson.model.Queue.Task) item).getDefaultAuthentication2()
-                  : ACL.SYSTEM2,
-              item,
-              StringCredentials.class,
-              Collections.<DomainRequirement>emptyList(),
-              CredentialsMatchers.always())
-          .includeCurrentValue(apiCredentialsId);
+    @DataBoundSetter
+    public void setModel(String model) {
+        this.model = Util.fixNull(model);
     }
 
-    @POST
-    public FormValidation doCheckApprovalTimeoutSeconds(
-        @AncestorInPath Item item,
-        @QueryParameter String value,
-        @QueryParameter String requireApprovals) {
-      checkConfigurationPermission(item);
-      if (!isTruthy(requireApprovals)) {
-        return FormValidation.ok();
-      }
-      if (value == null || value.trim().isEmpty()) {
-        return FormValidation.error("Timeout is required.");
-      }
-      try {
-        int parsed = Integer.parseInt(value.trim());
-        if (parsed < 1) {
-          return FormValidation.error("Timeout must be at least 1 second.");
+    @Override
+    public String getPrompt() {
+        return prompt;
+    }
+
+    @DataBoundSetter
+    public void setPrompt(String prompt) {
+        this.prompt = Util.fixNull(prompt);
+    }
+
+    @Override
+    public String getWorkingDirectory() {
+        return workingDirectory;
+    }
+
+    @DataBoundSetter
+    public void setWorkingDirectory(String workingDirectory) {
+        this.workingDirectory = Util.fixNull(workingDirectory);
+    }
+
+    @Override
+    public boolean isYoloMode() {
+        return yoloMode;
+    }
+
+    @DataBoundSetter
+    public void setYoloMode(boolean yoloMode) {
+        this.yoloMode = yoloMode;
+    }
+
+    @Override
+    public boolean isRequireApprovals() {
+        return requireApprovals;
+    }
+
+    @DataBoundSetter
+    public void setRequireApprovals(boolean requireApprovals) {
+        this.requireApprovals = requireApprovals;
+    }
+
+    @Override
+    public int getApprovalTimeoutSeconds() {
+        return approvalTimeoutSeconds;
+    }
+
+    @DataBoundSetter
+    public void setApprovalTimeoutSeconds(int approvalTimeoutSeconds) {
+        this.approvalTimeoutSeconds = Math.max(1, approvalTimeoutSeconds);
+    }
+
+    @Override
+    public String getCommandOverride() {
+        return commandOverride;
+    }
+
+    @DataBoundSetter
+    public void setCommandOverride(String commandOverride) {
+        this.commandOverride = normalizeCommandOverride(commandOverride);
+    }
+
+    @Override
+    public String getExtraArgs() {
+        return extraArgs;
+    }
+
+    @DataBoundSetter
+    public void setExtraArgs(String extraArgs) {
+        this.extraArgs = Util.fixNull(extraArgs);
+    }
+
+    @Override
+    public String getEnvironmentVariables() {
+        return environmentVariables;
+    }
+
+    @DataBoundSetter
+    public void setEnvironmentVariables(String environmentVariables) {
+        this.environmentVariables = Util.fixNull(environmentVariables);
+    }
+
+    @Override
+    public boolean isFailOnAgentError() {
+        return failOnAgentError;
+    }
+
+    @DataBoundSetter
+    public void setFailOnAgentError(boolean failOnAgentError) {
+        this.failOnAgentError = failOnAgentError;
+    }
+
+    @Override
+    public String getSetupScript() {
+        return setupScript;
+    }
+
+    @DataBoundSetter
+    public void setSetupScript(String setupScript) {
+        this.setupScript = Util.fixNull(setupScript);
+    }
+
+    @Override
+    public String getApiCredentialsId() {
+        return apiCredentialsId;
+    }
+
+    @DataBoundSetter
+    public void setApiCredentialsId(String apiCredentialsId) {
+        this.apiCredentialsId = Util.fixNull(apiCredentialsId);
+    }
+
+    public String getApiEnvVarName() {
+        return apiEnvVarName;
+    }
+
+    @DataBoundSetter
+    public void setApiEnvVarName(String apiEnvVarName) {
+        this.apiEnvVarName = Util.fixNull(apiEnvVarName);
+    }
+
+    @Override
+    public boolean isDisableInteractive() {
+        return disableInteractive;
+    }
+
+    @DataBoundSetter
+    public void setDisableInteractive(boolean disableInteractive) {
+        this.disableInteractive = disableInteractive;
+    }
+
+    @Override
+    public String getEffectiveApiKeyEnvVar() {
+        String custom = Util.fixEmptyAndTrim(apiEnvVarName);
+        return custom != null ? custom : getAgent().getDefaultApiKeyEnvVar();
+    }
+
+    private Object readResolve() {
+        if (agent == null) {
+            agent = new ClaudeCodeAgentHandler();
         }
-        if (parsed > 86400) {
-          return FormValidation.warning(
-              "Large timeout values will block executors for a long time.");
+        model = Util.fixNull(model);
+        prompt = Util.fixNull(prompt);
+        workingDirectory = Util.fixNull(workingDirectory);
+        commandOverride = normalizeCommandOverride(commandOverride);
+        extraArgs = Util.fixNull(extraArgs);
+        environmentVariables = Util.fixNull(environmentVariables);
+        setupScript = Util.fixNull(setupScript);
+        apiCredentialsId = Util.fixNull(apiCredentialsId);
+        apiEnvVarName = Util.fixNull(apiEnvVarName);
+        approvalTimeoutSeconds = Math.max(1, approvalTimeoutSeconds);
+        return this;
+    }
+
+    private static String normalizeCommandOverride(String commandOverride) {
+        return Util.fixNull(commandOverride).replaceAll("\\s*[\\r\\n]+\\s*", " ").trim();
+    }
+
+    @Extension
+    @Symbol("aiAgent")
+    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+        public List<Descriptor<AiAgentTypeHandler>> getAgentDescriptors() {
+            return DescriptorVisibilityFilter.apply(
+                    null, Jenkins.get().getDescriptorList(AiAgentTypeHandler.class));
         }
-        return FormValidation.ok();
-      } catch (NumberFormatException e) {
-        return FormValidation.error("Timeout must be a number.");
-      }
-    }
 
-    private static boolean isTruthy(String raw) {
-      if (raw == null) {
-        return false;
-      }
-      String normalized = raw.trim().toLowerCase(java.util.Locale.ROOT);
-      return "true".equals(normalized)
-          || "on".equals(normalized)
-          || "yes".equals(normalized)
-          || "1".equals(normalized);
-    }
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
 
-    private static void checkConfigurationPermission(Item item) {
-      if (item != null) {
-        item.checkPermission(Item.CONFIGURE);
-        return;
-      }
-      Jenkins.get().checkPermission(Item.CREATE);
+        @Override
+        public String getDisplayName() {
+            return "Run AI Agent";
+        }
+
+        @POST
+        public ListBoxModel doFillApiCredentialsIdItems(
+                @AncestorInPath Item item, @QueryParameter String apiCredentialsId) {
+            checkConfigurationPermission(item);
+            StandardListBoxModel result = new StandardListBoxModel();
+            return result.includeEmptyValue()
+                    .includeMatchingAs(
+                            item instanceof hudson.model.Queue.Task
+                                    ? ((hudson.model.Queue.Task) item).getDefaultAuthentication2()
+                                    : ACL.SYSTEM2,
+                            item,
+                            StringCredentials.class,
+                            Collections.<DomainRequirement>emptyList(),
+                            CredentialsMatchers.always())
+                    .includeCurrentValue(apiCredentialsId);
+        }
+
+        @POST
+        public FormValidation doCheckApprovalTimeoutSeconds(
+                @AncestorInPath Item item,
+                @QueryParameter String value,
+                @QueryParameter String requireApprovals) {
+            checkConfigurationPermission(item);
+            if (!isTruthy(requireApprovals)) {
+                return FormValidation.ok();
+            }
+            if (value == null || value.trim().isEmpty()) {
+                return FormValidation.error("Timeout is required.");
+            }
+            try {
+                int parsed = Integer.parseInt(value.trim());
+                if (parsed < 1) {
+                    return FormValidation.error("Timeout must be at least 1 second.");
+                }
+                if (parsed > 86400) {
+                    return FormValidation.warning(
+                            "Large timeout values will block executors for a long time.");
+                }
+                return FormValidation.ok();
+            } catch (NumberFormatException e) {
+                return FormValidation.error("Timeout must be a number.");
+            }
+        }
+
+        private static boolean isTruthy(String raw) {
+            if (raw == null) {
+                return false;
+            }
+            String normalized = raw.trim().toLowerCase(java.util.Locale.ROOT);
+            return "true".equals(normalized)
+                    || "on".equals(normalized)
+                    || "yes".equals(normalized)
+                    || "1".equals(normalized);
+        }
+
+        private static void checkConfigurationPermission(Item item) {
+            if (item != null) {
+                item.checkPermission(Item.CONFIGURE);
+                return;
+            }
+            Jenkins.get().checkPermission(Item.CREATE);
+        }
     }
-  }
 }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentBuilder.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentBuilder.java
@@ -3,7 +3,6 @@ package io.jenkins.plugins.aiagentjob;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -20,12 +19,12 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
-
 import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeAgentHandler;
-
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import jenkins.model.Jenkins;
 import jenkins.tasks.SimpleBuildStep;
-
 import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.AncestorInPath;
@@ -34,314 +33,305 @@ import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.verb.POST;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.List;
-
 /** Build step that runs AI coding agents and can be used from freestyle and pipeline jobs. */
 public class AiAgentBuilder extends Builder implements SimpleBuildStep, AiAgentConfiguration {
-    private AiAgentTypeHandler agent = new ClaudeCodeAgentHandler();
-    private String model = "";
-    private String prompt = "";
-    private String workingDirectory = "";
-    private boolean yoloMode;
-    private boolean requireApprovals;
-    private int approvalTimeoutSeconds = 600;
-    private String commandOverride = "";
-    private String extraArgs = "";
-    private String environmentVariables = "";
-    private boolean failOnAgentError = true;
-    private String setupScript = "";
-    private String apiCredentialsId = "";
-    private String apiEnvVarName = "";
-    private boolean disableInteractive;
+  private AiAgentTypeHandler agent = new ClaudeCodeAgentHandler();
+  private String model = "";
+  private String prompt = "";
+  private String workingDirectory = "";
+  private boolean yoloMode;
+  private boolean requireApprovals;
+  private int approvalTimeoutSeconds = 600;
+  private String commandOverride = "";
+  private String extraArgs = "";
+  private String environmentVariables = "";
+  private boolean failOnAgentError = true;
+  private String setupScript = "";
+  private String apiCredentialsId = "";
+  private String apiEnvVarName = "";
+  private boolean disableInteractive;
 
-    @DataBoundConstructor
-    public AiAgentBuilder() {}
+  @DataBoundConstructor
+  public AiAgentBuilder() {}
+
+  @Override
+  public void perform(
+      Run<?, ?> run, FilePath workspace, EnvVars env, Launcher launcher, TaskListener listener)
+      throws InterruptedException, IOException {
+    AiAgentRunAction action = AiAgentRunAction.getOrCreate(run);
+    int exitCode = AiAgentExecutor.execute(run, workspace, env, launcher, listener, this, action);
+    if (exitCode != 0 && isFailOnAgentError()) {
+      listener
+          .getLogger()
+          .println("[ai-agent] Agent finished with non-zero exit code: " + exitCode);
+      throw new IOException("AI agent finished with non-zero exit code: " + exitCode);
+    }
+    if (exitCode != 0) {
+      listener
+          .getLogger()
+          .println("[ai-agent] Agent exited with code " + exitCode + ", but failure is disabled.");
+    }
+  }
+
+  @Override
+  public AiAgentTypeHandler getAgent() {
+    if (agent == null) {
+      agent = new ClaudeCodeAgentHandler();
+    }
+    return agent;
+  }
+
+  @DataBoundSetter
+  public void setAgent(AiAgentTypeHandler agent) {
+    this.agent = agent == null ? new ClaudeCodeAgentHandler() : agent;
+  }
+
+  @Override
+  public String getModel() {
+    return model;
+  }
+
+  @DataBoundSetter
+  public void setModel(String model) {
+    this.model = Util.fixNull(model);
+  }
+
+  @Override
+  public String getPrompt() {
+    return prompt;
+  }
+
+  @DataBoundSetter
+  public void setPrompt(String prompt) {
+    this.prompt = Util.fixNull(prompt);
+  }
+
+  @Override
+  public String getWorkingDirectory() {
+    return workingDirectory;
+  }
+
+  @DataBoundSetter
+  public void setWorkingDirectory(String workingDirectory) {
+    this.workingDirectory = Util.fixNull(workingDirectory);
+  }
+
+  @Override
+  public boolean isYoloMode() {
+    return yoloMode;
+  }
+
+  @DataBoundSetter
+  public void setYoloMode(boolean yoloMode) {
+    this.yoloMode = yoloMode;
+  }
+
+  @Override
+  public boolean isRequireApprovals() {
+    return requireApprovals;
+  }
+
+  @DataBoundSetter
+  public void setRequireApprovals(boolean requireApprovals) {
+    this.requireApprovals = requireApprovals;
+  }
+
+  @Override
+  public int getApprovalTimeoutSeconds() {
+    return approvalTimeoutSeconds;
+  }
+
+  @DataBoundSetter
+  public void setApprovalTimeoutSeconds(int approvalTimeoutSeconds) {
+    this.approvalTimeoutSeconds = Math.max(1, approvalTimeoutSeconds);
+  }
+
+  @Override
+  public String getCommandOverride() {
+    return commandOverride;
+  }
+
+  @DataBoundSetter
+  public void setCommandOverride(String commandOverride) {
+    this.commandOverride = normalizeCommandOverride(commandOverride);
+  }
+
+  @Override
+  public String getExtraArgs() {
+    return extraArgs;
+  }
+
+  @DataBoundSetter
+  public void setExtraArgs(String extraArgs) {
+    this.extraArgs = Util.fixNull(extraArgs);
+  }
+
+  @Override
+  public String getEnvironmentVariables() {
+    return environmentVariables;
+  }
+
+  @DataBoundSetter
+  public void setEnvironmentVariables(String environmentVariables) {
+    this.environmentVariables = Util.fixNull(environmentVariables);
+  }
+
+  @Override
+  public boolean isFailOnAgentError() {
+    return failOnAgentError;
+  }
+
+  @DataBoundSetter
+  public void setFailOnAgentError(boolean failOnAgentError) {
+    this.failOnAgentError = failOnAgentError;
+  }
+
+  @Override
+  public String getSetupScript() {
+    return setupScript;
+  }
+
+  @DataBoundSetter
+  public void setSetupScript(String setupScript) {
+    this.setupScript = Util.fixNull(setupScript);
+  }
+
+  @Override
+  public String getApiCredentialsId() {
+    return apiCredentialsId;
+  }
+
+  @DataBoundSetter
+  public void setApiCredentialsId(String apiCredentialsId) {
+    this.apiCredentialsId = Util.fixNull(apiCredentialsId);
+  }
+
+  public String getApiEnvVarName() {
+    return apiEnvVarName;
+  }
+
+  @DataBoundSetter
+  public void setApiEnvVarName(String apiEnvVarName) {
+    this.apiEnvVarName = Util.fixNull(apiEnvVarName);
+  }
+
+  @Override
+  public boolean isDisableInteractive() {
+    return disableInteractive;
+  }
+
+  @DataBoundSetter
+  public void setDisableInteractive(boolean disableInteractive) {
+    this.disableInteractive = disableInteractive;
+  }
+
+  @Override
+  public String getEffectiveApiKeyEnvVar() {
+    String custom = Util.fixEmptyAndTrim(apiEnvVarName);
+    return custom != null ? custom : getAgent().getDefaultApiKeyEnvVar();
+  }
+
+  private Object readResolve() {
+    if (agent == null) {
+      agent = new ClaudeCodeAgentHandler();
+    }
+    model = Util.fixNull(model);
+    prompt = Util.fixNull(prompt);
+    workingDirectory = Util.fixNull(workingDirectory);
+    commandOverride = normalizeCommandOverride(commandOverride);
+    extraArgs = Util.fixNull(extraArgs);
+    environmentVariables = Util.fixNull(environmentVariables);
+    setupScript = Util.fixNull(setupScript);
+    apiCredentialsId = Util.fixNull(apiCredentialsId);
+    apiEnvVarName = Util.fixNull(apiEnvVarName);
+    approvalTimeoutSeconds = Math.max(1, approvalTimeoutSeconds);
+    return this;
+  }
+
+  private static String normalizeCommandOverride(String commandOverride) {
+    return Util.fixNull(commandOverride).replaceAll("\\s*[\\r\\n]+\\s*", " ").trim();
+  }
+
+  @Extension
+  @Symbol("aiAgent")
+  public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
+    public List<Descriptor<AiAgentTypeHandler>> getAgentDescriptors() {
+      return DescriptorVisibilityFilter.apply(
+          null, Jenkins.get().getDescriptorList(AiAgentTypeHandler.class));
+    }
 
     @Override
-    public void perform(
-            Run<?, ?> run,
-            FilePath workspace,
-            EnvVars env,
-            Launcher launcher,
-            TaskListener listener)
-            throws InterruptedException, IOException {
-        AiAgentRunAction action = AiAgentRunAction.getOrCreate(run);
-        int exitCode =
-                AiAgentExecutor.execute(run, workspace, env, launcher, listener, this, action);
-        if (exitCode != 0 && isFailOnAgentError()) {
-            listener.getLogger()
-                    .println("[ai-agent] Agent finished with non-zero exit code: " + exitCode);
-            throw new IOException("AI agent finished with non-zero exit code: " + exitCode);
+    public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+      return true;
+    }
+
+    @Override
+    public String getDisplayName() {
+      return "Run AI Agent";
+    }
+
+    @POST
+    public ListBoxModel doFillApiCredentialsIdItems(
+        @AncestorInPath Item item, @QueryParameter String apiCredentialsId) {
+      checkConfigurationPermission(item);
+      StandardListBoxModel result = new StandardListBoxModel();
+      return result
+          .includeEmptyValue()
+          .includeMatchingAs(
+              item instanceof hudson.model.Queue.Task
+                  ? ((hudson.model.Queue.Task) item).getDefaultAuthentication2()
+                  : ACL.SYSTEM2,
+              item,
+              StringCredentials.class,
+              Collections.<DomainRequirement>emptyList(),
+              CredentialsMatchers.always())
+          .includeCurrentValue(apiCredentialsId);
+    }
+
+    @POST
+    public FormValidation doCheckApprovalTimeoutSeconds(
+        @AncestorInPath Item item,
+        @QueryParameter String value,
+        @QueryParameter String requireApprovals) {
+      checkConfigurationPermission(item);
+      if (!isTruthy(requireApprovals)) {
+        return FormValidation.ok();
+      }
+      if (value == null || value.trim().isEmpty()) {
+        return FormValidation.error("Timeout is required.");
+      }
+      try {
+        int parsed = Integer.parseInt(value.trim());
+        if (parsed < 1) {
+          return FormValidation.error("Timeout must be at least 1 second.");
         }
-        if (exitCode != 0) {
-            listener.getLogger()
-                    .println(
-                            "[ai-agent] Agent exited with code "
-                                    + exitCode
-                                    + ", but failure is disabled.");
+        if (parsed > 86400) {
+          return FormValidation.warning(
+              "Large timeout values will block executors for a long time.");
         }
+        return FormValidation.ok();
+      } catch (NumberFormatException e) {
+        return FormValidation.error("Timeout must be a number.");
+      }
     }
 
-    @Override
-    public AiAgentTypeHandler getAgent() {
-        if (agent == null) {
-            agent = new ClaudeCodeAgentHandler();
-        }
-        return agent;
+    private static boolean isTruthy(String raw) {
+      if (raw == null) {
+        return false;
+      }
+      String normalized = raw.trim().toLowerCase(java.util.Locale.ROOT);
+      return "true".equals(normalized)
+          || "on".equals(normalized)
+          || "yes".equals(normalized)
+          || "1".equals(normalized);
     }
 
-    @DataBoundSetter
-    public void setAgent(AiAgentTypeHandler agent) {
-        this.agent = agent == null ? new ClaudeCodeAgentHandler() : agent;
+    private static void checkConfigurationPermission(Item item) {
+      if (item != null) {
+        item.checkPermission(Item.CONFIGURE);
+        return;
+      }
+      Jenkins.get().checkPermission(Item.CREATE);
     }
-
-    @Override
-    public String getModel() {
-        return model;
-    }
-
-    @DataBoundSetter
-    public void setModel(String model) {
-        this.model = Util.fixNull(model);
-    }
-
-    @Override
-    public String getPrompt() {
-        return prompt;
-    }
-
-    @DataBoundSetter
-    public void setPrompt(String prompt) {
-        this.prompt = Util.fixNull(prompt);
-    }
-
-    @Override
-    public String getWorkingDirectory() {
-        return workingDirectory;
-    }
-
-    @DataBoundSetter
-    public void setWorkingDirectory(String workingDirectory) {
-        this.workingDirectory = Util.fixNull(workingDirectory);
-    }
-
-    @Override
-    public boolean isYoloMode() {
-        return yoloMode;
-    }
-
-    @DataBoundSetter
-    public void setYoloMode(boolean yoloMode) {
-        this.yoloMode = yoloMode;
-    }
-
-    @Override
-    public boolean isRequireApprovals() {
-        return requireApprovals;
-    }
-
-    @DataBoundSetter
-    public void setRequireApprovals(boolean requireApprovals) {
-        this.requireApprovals = requireApprovals;
-    }
-
-    @Override
-    public int getApprovalTimeoutSeconds() {
-        return approvalTimeoutSeconds;
-    }
-
-    @DataBoundSetter
-    public void setApprovalTimeoutSeconds(int approvalTimeoutSeconds) {
-        this.approvalTimeoutSeconds = Math.max(1, approvalTimeoutSeconds);
-    }
-
-    @Override
-    public String getCommandOverride() {
-        return commandOverride;
-    }
-
-    @DataBoundSetter
-    public void setCommandOverride(String commandOverride) {
-        this.commandOverride = normalizeCommandOverride(commandOverride);
-    }
-
-    @Override
-    public String getExtraArgs() {
-        return extraArgs;
-    }
-
-    @DataBoundSetter
-    public void setExtraArgs(String extraArgs) {
-        this.extraArgs = Util.fixNull(extraArgs);
-    }
-
-    @Override
-    public String getEnvironmentVariables() {
-        return environmentVariables;
-    }
-
-    @DataBoundSetter
-    public void setEnvironmentVariables(String environmentVariables) {
-        this.environmentVariables = Util.fixNull(environmentVariables);
-    }
-
-    @Override
-    public boolean isFailOnAgentError() {
-        return failOnAgentError;
-    }
-
-    @DataBoundSetter
-    public void setFailOnAgentError(boolean failOnAgentError) {
-        this.failOnAgentError = failOnAgentError;
-    }
-
-    @Override
-    public String getSetupScript() {
-        return setupScript;
-    }
-
-    @DataBoundSetter
-    public void setSetupScript(String setupScript) {
-        this.setupScript = Util.fixNull(setupScript);
-    }
-
-    @Override
-    public String getApiCredentialsId() {
-        return apiCredentialsId;
-    }
-
-    @DataBoundSetter
-    public void setApiCredentialsId(String apiCredentialsId) {
-        this.apiCredentialsId = Util.fixNull(apiCredentialsId);
-    }
-
-    public String getApiEnvVarName() {
-        return apiEnvVarName;
-    }
-
-    @DataBoundSetter
-    public void setApiEnvVarName(String apiEnvVarName) {
-        this.apiEnvVarName = Util.fixNull(apiEnvVarName);
-    }
-
-    @Override
-    public boolean isDisableInteractive() {
-        return disableInteractive;
-    }
-
-    @DataBoundSetter
-    public void setDisableInteractive(boolean disableInteractive) {
-        this.disableInteractive = disableInteractive;
-    }
-
-    @Override
-    public String getEffectiveApiKeyEnvVar() {
-        String custom = Util.fixEmptyAndTrim(apiEnvVarName);
-        return custom != null ? custom : getAgent().getDefaultApiKeyEnvVar();
-    }
-
-    private Object readResolve() {
-        if (agent == null) {
-            agent = new ClaudeCodeAgentHandler();
-        }
-        model = Util.fixNull(model);
-        prompt = Util.fixNull(prompt);
-        workingDirectory = Util.fixNull(workingDirectory);
-        commandOverride = normalizeCommandOverride(commandOverride);
-        extraArgs = Util.fixNull(extraArgs);
-        environmentVariables = Util.fixNull(environmentVariables);
-        setupScript = Util.fixNull(setupScript);
-        apiCredentialsId = Util.fixNull(apiCredentialsId);
-        apiEnvVarName = Util.fixNull(apiEnvVarName);
-        approvalTimeoutSeconds = Math.max(1, approvalTimeoutSeconds);
-        return this;
-    }
-
-    private static String normalizeCommandOverride(String commandOverride) {
-        return Util.fixNull(commandOverride).replaceAll("\\s*[\\r\\n]+\\s*", " ").trim();
-    }
-
-    @Extension
-    @Symbol("aiAgent")
-    public static final class DescriptorImpl extends BuildStepDescriptor<Builder> {
-        public List<Descriptor<AiAgentTypeHandler>> getAgentDescriptors() {
-            return DescriptorVisibilityFilter.apply(
-                    null, Jenkins.get().getDescriptorList(AiAgentTypeHandler.class));
-        }
-
-        @Override
-        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
-            return true;
-        }
-
-        @Override
-        public String getDisplayName() {
-            return "Run AI Agent";
-        }
-
-        @POST
-        public ListBoxModel doFillApiCredentialsIdItems(
-                @AncestorInPath Item item, @QueryParameter String apiCredentialsId) {
-            checkConfigurationPermission(item);
-            StandardListBoxModel result = new StandardListBoxModel();
-            return result.includeEmptyValue()
-                    .includeMatchingAs(
-                            item instanceof hudson.model.Queue.Task
-                                    ? ((hudson.model.Queue.Task) item).getDefaultAuthentication2()
-                                    : ACL.SYSTEM2,
-                            item,
-                            StringCredentials.class,
-                            Collections.<DomainRequirement>emptyList(),
-                            CredentialsMatchers.always())
-                    .includeCurrentValue(apiCredentialsId);
-        }
-
-        @POST
-        public FormValidation doCheckApprovalTimeoutSeconds(
-                @AncestorInPath Item item,
-                @QueryParameter String value,
-                @QueryParameter String requireApprovals) {
-            checkConfigurationPermission(item);
-            if (!isTruthy(requireApprovals)) {
-                return FormValidation.ok();
-            }
-            if (value == null || value.trim().isEmpty()) {
-                return FormValidation.error("Timeout is required.");
-            }
-            try {
-                int parsed = Integer.parseInt(value.trim());
-                if (parsed < 1) {
-                    return FormValidation.error("Timeout must be at least 1 second.");
-                }
-                if (parsed > 86400) {
-                    return FormValidation.warning(
-                            "Large timeout values will block executors for a long time.");
-                }
-                return FormValidation.ok();
-            } catch (NumberFormatException e) {
-                return FormValidation.error("Timeout must be a number.");
-            }
-        }
-
-        private static boolean isTruthy(String raw) {
-            if (raw == null) {
-                return false;
-            }
-            String normalized = raw.trim().toLowerCase(java.util.Locale.ROOT);
-            return "true".equals(normalized)
-                    || "on".equals(normalized)
-                    || "yes".equals(normalized)
-                    || "1".equals(normalized);
-        }
-
-        private static void checkConfigurationPermission(Item item) {
-            if (item != null) {
-                item.checkPermission(Item.CONFIGURE);
-                return;
-            }
-            Jenkins.get().checkPermission(Item.CREATE);
-        }
-    }
+  }
 }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentBuilder.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentBuilder.java
@@ -54,6 +54,7 @@ public class AiAgentBuilder extends Builder implements SimpleBuildStep, AiAgentC
     private String setupScript = "";
     private String apiCredentialsId = "";
     private String apiEnvVarName = "";
+    private boolean disableInteractive;
 
     @DataBoundConstructor
     public AiAgentBuilder() {}
@@ -223,6 +224,16 @@ public class AiAgentBuilder extends Builder implements SimpleBuildStep, AiAgentC
     @DataBoundSetter
     public void setApiEnvVarName(String apiEnvVarName) {
         this.apiEnvVarName = Util.fixNull(apiEnvVarName);
+    }
+
+    @Override
+    public boolean isDisableInteractive() {
+        return disableInteractive;
+    }
+
+    @DataBoundSetter
+    public void setDisableInteractive(boolean disableInteractive) {
+        this.disableInteractive = disableInteractive;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentConfiguration.java
@@ -2,33 +2,33 @@ package io.jenkins.plugins.aiagentjob;
 
 /** Shared execution settings used by the AI agent builder step and command execution flow. */
 public interface AiAgentConfiguration {
-  AiAgentTypeHandler getAgent();
+    AiAgentTypeHandler getAgent();
 
-  String getModel();
+    String getModel();
 
-  String getPrompt();
+    String getPrompt();
 
-  String getWorkingDirectory();
+    String getWorkingDirectory();
 
-  boolean isYoloMode();
+    boolean isYoloMode();
 
-  boolean isRequireApprovals();
+    boolean isRequireApprovals();
 
-  int getApprovalTimeoutSeconds();
+    int getApprovalTimeoutSeconds();
 
-  String getCommandOverride();
+    String getCommandOverride();
 
-  String getExtraArgs();
+    String getExtraArgs();
 
-  String getEnvironmentVariables();
+    String getEnvironmentVariables();
 
-  boolean isFailOnAgentError();
+    boolean isFailOnAgentError();
 
-  String getSetupScript();
+    String getSetupScript();
 
-  String getApiCredentialsId();
+    String getApiCredentialsId();
 
-  String getEffectiveApiKeyEnvVar();
+    String getEffectiveApiKeyEnvVar();
 
-  boolean isDisableInteractive();
+    boolean isDisableInteractive();
 }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentConfiguration.java
@@ -2,33 +2,33 @@ package io.jenkins.plugins.aiagentjob;
 
 /** Shared execution settings used by the AI agent builder step and command execution flow. */
 public interface AiAgentConfiguration {
-    AiAgentTypeHandler getAgent();
+  AiAgentTypeHandler getAgent();
 
-    String getModel();
+  String getModel();
 
-    String getPrompt();
+  String getPrompt();
 
-    String getWorkingDirectory();
+  String getWorkingDirectory();
 
-    boolean isYoloMode();
+  boolean isYoloMode();
 
-    boolean isRequireApprovals();
+  boolean isRequireApprovals();
 
-    int getApprovalTimeoutSeconds();
+  int getApprovalTimeoutSeconds();
 
-    String getCommandOverride();
+  String getCommandOverride();
 
-    String getExtraArgs();
+  String getExtraArgs();
 
-    String getEnvironmentVariables();
+  String getEnvironmentVariables();
 
-    boolean isFailOnAgentError();
+  boolean isFailOnAgentError();
 
-    String getSetupScript();
+  String getSetupScript();
 
-    String getApiCredentialsId();
+  String getApiCredentialsId();
 
-    String getEffectiveApiKeyEnvVar();
+  String getEffectiveApiKeyEnvVar();
 
-    boolean isDisableInteractive();
+  boolean isDisableInteractive();
 }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentConfiguration.java
@@ -29,4 +29,6 @@ public interface AiAgentConfiguration {
     String getApiCredentialsId();
 
     String getEffectiveApiKeyEnvVar();
+
+    boolean isDisableInteractive();
 }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.aiagentjob;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -11,9 +10,6 @@ import hudson.Util;
 import hudson.console.LineTransformationOutputStream;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-
-import org.jenkinsci.plugins.plaincredentials.StringCredentials;
-
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -29,451 +25,456 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 /**
  * Runs the AI agent subprocess, wires stdout/stderr to the Jenkins build log and the raw JSONL log
  * file, and handles the approval-gate flow when approvals are enabled.
  */
 final class AiAgentExecutor {
-    private AiAgentExecutor() {}
+  private AiAgentExecutor() {}
 
-    static int execute(
-            Run<?, ?> run,
-            FilePath workspace,
-            EnvVars stepEnv,
-            Launcher launcher,
-            TaskListener listener,
-            AiAgentConfiguration config,
-            AiAgentRunAction action)
-            throws IOException, InterruptedException {
-        EnvVars env = new EnvVars(stepEnv);
+  static int execute(
+      Run<?, ?> run,
+      FilePath workspace,
+      EnvVars stepEnv,
+      Launcher launcher,
+      TaskListener listener,
+      AiAgentConfiguration config,
+      AiAgentRunAction action)
+      throws IOException, InterruptedException {
+    EnvVars env = new EnvVars(stepEnv);
 
-        String prompt = Util.replaceMacro(Util.fixNull(config.getPrompt()), env);
-        String model = Util.replaceMacro(Util.fixNull(config.getModel()), env);
-        String workDirValue = Util.replaceMacro(Util.fixNull(config.getWorkingDirectory()), env);
-        String commandOverride = Util.fixNull(config.getCommandOverride()).trim();
+    String prompt = Util.replaceMacro(Util.fixNull(config.getPrompt()), env);
+    String model = Util.replaceMacro(Util.fixNull(config.getModel()), env);
+    String workDirValue = Util.replaceMacro(Util.fixNull(config.getWorkingDirectory()), env);
+    String commandOverride = Util.fixNull(config.getCommandOverride()).trim();
 
-        FilePath runDirectory = resolveRunDirectory(workspace, workDirValue);
-        runDirectory.mkdirs();
+    FilePath runDirectory = resolveRunDirectory(workspace, workDirValue);
+    runDirectory.mkdirs();
 
-        EnvVars procEnv = new EnvVars(env);
-        procEnv.putAll(
-                new LinkedHashMap<>(
-                        AiAgentCommandFactory.parseEnvironmentVariables(
-                                config.getEnvironmentVariables())));
+    EnvVars procEnv = new EnvVars(env);
+    procEnv.putAll(
+        new LinkedHashMap<>(
+            AiAgentCommandFactory.parseEnvironmentVariables(config.getEnvironmentVariables())));
 
-        // Inject API key from Jenkins Credentials if configured
-        String credentialsId = Util.fixEmptyAndTrim(config.getApiCredentialsId());
-        if (credentialsId != null) {
-            StringCredentials cred =
-                    CredentialsProvider.findCredentialById(
-                            credentialsId,
-                            StringCredentials.class,
-                            run,
-                            Collections.<DomainRequirement>emptyList());
-            if (cred != null) {
-                String envVarName = config.getEffectiveApiKeyEnvVar();
-                procEnv.put(envVarName, cred.getSecret().getPlainText());
-                listener.getLogger()
-                        .println(
-                                "[ai-agent] API key injected as "
-                                        + envVarName
-                                        + " from credential '"
-                                        + credentialsId
-                                        + "'");
-            } else {
-                listener.getLogger()
-                        .println(
-                                "[ai-agent] WARNING: Credential '"
-                                        + credentialsId
-                                        + "' not found. Agent may fail to authenticate.");
-            }
+    // Inject API key from Jenkins Credentials if configured
+    String credentialsId = Util.fixEmptyAndTrim(config.getApiCredentialsId());
+    if (credentialsId != null) {
+      StringCredentials cred =
+          CredentialsProvider.findCredentialById(
+              credentialsId,
+              StringCredentials.class,
+              run,
+              Collections.<DomainRequirement>emptyList());
+      if (cred != null) {
+        String envVarName = config.getEffectiveApiKeyEnvVar();
+        procEnv.put(envVarName, cred.getSecret().getPlainText());
+        listener
+            .getLogger()
+            .println(
+                "[ai-agent] API key injected as "
+                    + envVarName
+                    + " from credential '"
+                    + credentialsId
+                    + "'");
+      } else {
+        listener
+            .getLogger()
+            .println(
+                "[ai-agent] WARNING: Credential '"
+                    + credentialsId
+                    + "' not found. Agent may fail to authenticate.");
+      }
+    }
+
+    procEnv.put("AI_AGENT_PROMPT", prompt);
+    procEnv.put("AI_AGENT_MODEL", model);
+
+    String setupScript = Util.fixNull(config.getSetupScript()).trim();
+    if (!setupScript.isEmpty() && !launcher.isUnix()) {
+      throw new IOException(
+          "Setup script is currently supported only on Unix agents. "
+              + "Use Command override for Windows nodes.");
+    }
+    AiAgentExecutionCustomization executionCustomization =
+        config.getAgent().prepareExecution(config, workspace, listener);
+    procEnv.putAll(executionCustomization.getEnvironment());
+
+    List<String> agentCommand;
+    if (!commandOverride.isEmpty()) {
+      agentCommand = List.of(commandOverride);
+    } else {
+      agentCommand = AiAgentCommandFactory.buildDefaultCommand(config, prompt);
+    }
+
+    boolean needsShellEnvironmentBootstrap =
+        launcher.isUnix() && !executionCustomization.getEnvironment().isEmpty();
+    boolean forceUnixShell = config.isDisableInteractive() && launcher.isUnix();
+    List<String> command;
+    FilePath tempSetupScript = null;
+    if ((!setupScript.isEmpty() && launcher.isUnix())
+        || needsShellEnvironmentBootstrap
+        || forceUnixShell) {
+      String combinedScript =
+          buildCombinedScript(
+              setupScript,
+              executionCustomization.getEnvironment(),
+              agentCommand,
+              commandOverride,
+              config.isDisableInteractive());
+      tempSetupScript = writeTempScript(workspace, combinedScript);
+      command = buildShellCommand(combinedScript, tempSetupScript);
+    } else if (!commandOverride.isEmpty()) {
+      if (launcher.isUnix()) {
+        // Use a non-login shell so injected HOME/USERPROFILE are not overridden.
+        command = List.of("/bin/sh", "-c", commandOverride);
+      } else {
+        String cmd = commandOverride;
+        if (config.isDisableInteractive() && !cmd.toUpperCase().contains("< NUL")) {
+          cmd =
+              cmd.endsWith("\n") ? cmd.substring(0, cmd.length() - 1) + " < NUL\n" : cmd + " < NUL";
         }
+        command = List.of("cmd", "/c", cmd);
+      }
+    } else if (config.isDisableInteractive()) {
+      command =
+          List.of("cmd", "/c", AiAgentCommandFactory.commandAsString(agentCommand) + " < NUL");
+    } else {
+      command = agentCommand;
+    }
 
-        procEnv.put("AI_AGENT_PROMPT", prompt);
-        procEnv.put("AI_AGENT_MODEL", model);
+    if (!setupScript.isEmpty()) {
+      listener.getLogger().println("[ai-agent] Setup script will run before the agent.");
+    }
 
-        String setupScript = Util.fixNull(config.getSetupScript()).trim();
-        if (!setupScript.isEmpty() && !launcher.isUnix()) {
-            throw new IOException(
-                    "Setup script is currently supported only on Unix agents. "
-                            + "Use Command override for Windows nodes.");
-        }
-        AiAgentExecutionCustomization executionCustomization =
-                config.getAgent().prepareExecution(config, workspace, listener);
-        procEnv.putAll(executionCustomization.getEnvironment());
+    String commandLine =
+        commandOverride.isEmpty()
+            ? AiAgentCommandFactory.commandAsString(agentCommand)
+            : commandOverride;
+    int invocationId =
+        action.markStarted(
+            config.getAgent().getDescriptor().getDisplayName(),
+            prompt,
+            model,
+            commandLine,
+            config.isYoloMode(),
+            config.isRequireApprovals());
 
-        List<String> agentCommand;
-        if (!commandOverride.isEmpty()) {
-            agentCommand = List.of(commandOverride);
-        } else {
-            agentCommand = AiAgentCommandFactory.buildDefaultCommand(config, prompt);
-        }
+    File rawLogFile = action.getRawLogFile(invocationId);
+    Files.deleteIfExists(rawLogFile.toPath());
 
-        boolean needsShellEnvironmentBootstrap =
-                launcher.isUnix() && !executionCustomization.getEnvironment().isEmpty();
-        boolean forceUnixShell = config.isDisableInteractive() && launcher.isUnix();
-        List<String> command;
-        FilePath tempSetupScript = null;
-        if ((!setupScript.isEmpty() && launcher.isUnix()) || needsShellEnvironmentBootstrap || forceUnixShell) {
-            String combinedScript =
-                    buildCombinedScript(
-                            setupScript,
-                            executionCustomization.getEnvironment(),
-                            agentCommand,
-                            commandOverride,
-                            config.isDisableInteractive());
-            tempSetupScript = writeTempScript(workspace, combinedScript);
-            command = buildShellCommand(combinedScript, tempSetupScript);
-        } else if (!commandOverride.isEmpty()) {
-            if (launcher.isUnix()) {
-                // Use a non-login shell so injected HOME/USERPROFILE are not overridden.
-                command = List.of("/bin/sh", "-c", commandOverride);
-            } else {
-                String cmd = commandOverride;
-                if (config.isDisableInteractive() && !cmd.toUpperCase().contains("< NUL")) {
-                    cmd = cmd.endsWith("\n") ? cmd.substring(0, cmd.length() - 1) + " < NUL\n" : cmd + " < NUL";
-                }
-                command = List.of("cmd", "/c", cmd);
-            }
-        } else if (config.isDisableInteractive()) {
-            command = List.of("cmd", "/c", AiAgentCommandFactory.commandAsString(agentCommand) + " < NUL");
-        } else {
-            command = agentCommand;
-        }
+    ExecutionRegistry.LiveExecution liveExecution = ExecutionRegistry.register(run, invocationId);
+    Duration approvalTimeout = Duration.ofSeconds(Math.max(1, config.getApprovalTimeoutSeconds()));
 
-        if (!setupScript.isEmpty()) {
-            listener.getLogger().println("[ai-agent] Setup script will run before the agent.");
-        }
+    AgentOutputHandler outputHandler =
+        new AgentOutputHandler(
+            listener.getLogger(),
+            rawLogFile,
+            liveExecution,
+            config.isRequireApprovals() && !config.isYoloMode(),
+            approvalTimeout,
+            config.getAgent().getLogFormat());
+    OutputStream stdoutSink = new NonClosingSynchronizedOutputStream(outputHandler);
+    OutputStream stderrSink = new NonClosingSynchronizedOutputStream(outputHandler);
 
-        String commandLine =
-                commandOverride.isEmpty()
-                        ? AiAgentCommandFactory.commandAsString(agentCommand)
-                        : commandOverride;
-        int invocationId =
-                action.markStarted(
-                        config.getAgent().getDescriptor().getDisplayName(),
-                        prompt,
-                        model,
-                        commandLine,
-                        config.isYoloMode(),
-                        config.isRequireApprovals());
-
-        File rawLogFile = action.getRawLogFile(invocationId);
-        Files.deleteIfExists(rawLogFile.toPath());
-
-        ExecutionRegistry.LiveExecution liveExecution =
-                ExecutionRegistry.register(run, invocationId);
-        Duration approvalTimeout =
-                Duration.ofSeconds(Math.max(1, config.getApprovalTimeoutSeconds()));
-
-        AgentOutputHandler outputHandler =
-                new AgentOutputHandler(
-                        listener.getLogger(),
-                        rawLogFile,
-                        liveExecution,
-                        config.isRequireApprovals() && !config.isYoloMode(),
-                        approvalTimeout,
-                        config.getAgent().getLogFormat());
-        OutputStream stdoutSink = new NonClosingSynchronizedOutputStream(outputHandler);
-        OutputStream stderrSink = new NonClosingSynchronizedOutputStream(outputHandler);
-
-        int exitCode;
+    int exitCode;
+    try {
+      Proc proc =
+          launcher
+              .launch()
+              .cmds(command)
+              .pwd(runDirectory)
+              .envs(procEnv)
+              .stdout(stdoutSink)
+              .stderr(stderrSink)
+              .quiet(true)
+              .start();
+      outputHandler.attach(proc);
+      exitCode = proc.join();
+    } finally {
+      outputHandler.close();
+      ExecutionRegistry.unregister(run, invocationId);
+      if (tempSetupScript != null) {
         try {
-            Proc proc =
-                    launcher.launch()
-                            .cmds(command)
-                            .pwd(runDirectory)
-                            .envs(procEnv)
-                            .stdout(stdoutSink)
-                            .stderr(stderrSink)
-                            .quiet(true)
-                            .start();
-            outputHandler.attach(proc);
-            exitCode = proc.join();
-        } finally {
-            outputHandler.close();
-            ExecutionRegistry.unregister(run, invocationId);
-            if (tempSetupScript != null) {
-                try {
-                    tempSetupScript.delete();
-                } catch (IOException e) {
-                    listener.getLogger()
-                            .println(
-                                    "[ai-agent] Warning: could not delete temp script: "
-                                            + e.getMessage());
-                }
-            }
-            executionCustomization.cleanup(listener);
+          tempSetupScript.delete();
+        } catch (IOException e) {
+          listener
+              .getLogger()
+              .println("[ai-agent] Warning: could not delete temp script: " + e.getMessage());
         }
-
-        if (outputHandler.wasDeniedByApproval()) {
-            exitCode = 1;
-        }
-        action.markCompleted(invocationId, exitCode);
-        return exitCode;
+      }
+      executionCustomization.cleanup(listener);
     }
 
-    private static String buildCombinedScript(
-            String setupScript,
-            Map<String, String> shellEnvironment,
-            List<String> agentCommand,
-            String commandOverride,
-            boolean disableInteractive) {
-        StringBuilder sb = new StringBuilder();
-        appendShebangAwarePreamble(sb, setupScript, shellEnvironment);
-        if (!commandOverride.isEmpty()) {
-            String cmd = commandOverride;
-            if (disableInteractive && !cmd.contains("< /dev/null")) {
-                cmd = cmd.endsWith("\n") ? cmd.substring(0, cmd.length() - 1) + " < /dev/null\n" : cmd + " < /dev/null";
-            }
-            sb.append(cmd);
-            if (!cmd.endsWith("\n")) {
-                sb.append('\n');
-            }
-        } else {
-            sb.append("exec");
-            for (String token : agentCommand) {
-                sb.append(' ').append(shellQuote(token));
-            }
-            if (disableInteractive) {
-                sb.append(" < /dev/null");
-            }
-            sb.append('\n');
+    if (outputHandler.wasDeniedByApproval()) {
+      exitCode = 1;
+    }
+    action.markCompleted(invocationId, exitCode);
+    return exitCode;
+  }
+
+  private static String buildCombinedScript(
+      String setupScript,
+      Map<String, String> shellEnvironment,
+      List<String> agentCommand,
+      String commandOverride,
+      boolean disableInteractive) {
+    StringBuilder sb = new StringBuilder();
+    appendShebangAwarePreamble(sb, setupScript, shellEnvironment);
+    if (!commandOverride.isEmpty()) {
+      String cmd = commandOverride;
+      if (disableInteractive && !cmd.contains("< /dev/null")) {
+        cmd =
+            cmd.endsWith("\n")
+                ? cmd.substring(0, cmd.length() - 1) + " < /dev/null\n"
+                : cmd + " < /dev/null";
+      }
+      sb.append(cmd);
+      if (!cmd.endsWith("\n")) {
+        sb.append('\n');
+      }
+    } else {
+      sb.append("exec");
+      for (String token : agentCommand) {
+        sb.append(' ').append(shellQuote(token));
+      }
+      if (disableInteractive) {
+        sb.append(" < /dev/null");
+      }
+      sb.append('\n');
+    }
+    return sb.toString();
+  }
+
+  private static void appendShebangAwarePreamble(
+      StringBuilder sb, String setupScript, Map<String, String> shellEnvironment) {
+    String normalizedSetupScript = Util.fixNull(setupScript);
+    if (normalizedSetupScript.startsWith("#!")) {
+      int end = normalizedSetupScript.indexOf('\n');
+      if (end < 0) {
+        end = normalizedSetupScript.length();
+      }
+      sb.append(normalizedSetupScript, 0, end).append('\n');
+      appendShellExports(sb, shellEnvironment);
+      if (end < normalizedSetupScript.length()) {
+        sb.append(normalizedSetupScript.substring(end + 1));
+        if (!normalizedSetupScript.endsWith("\n")) {
+          sb.append('\n');
         }
-        return sb.toString();
+      }
+      return;
+    }
+    appendShellExports(sb, shellEnvironment);
+    sb.append(normalizedSetupScript);
+    if (!normalizedSetupScript.isEmpty() && !normalizedSetupScript.endsWith("\n")) {
+      sb.append('\n');
+    }
+  }
+
+  private static void appendShellExports(StringBuilder sb, Map<String, String> shellEnvironment) {
+    for (Map.Entry<String, String> entry : shellEnvironment.entrySet()) {
+      String key = entry.getKey();
+      if (key == null || key.isBlank()) {
+        continue;
+      }
+      sb.append("export ")
+          .append(key)
+          .append('=')
+          .append(shellQuote(entry.getValue() == null ? "" : entry.getValue()))
+          .append('\n');
+    }
+  }
+
+  /**
+   * Writes the combined script to an agent-local temp area so the AI agent never sees it in the
+   * project workspace.
+   */
+  private static FilePath writeTempScript(FilePath workspace, String combinedScript)
+      throws IOException, InterruptedException {
+    FilePath tempDir = AiAgentTempFiles.tempRoot(workspace);
+    FilePath tempScript = tempDir.createTextTempFile("ai-agent-setup", ".sh", combinedScript);
+    tempScript.chmod(0755);
+    return tempScript;
+  }
+
+  /**
+   * Builds the shell command to run the combined script, honoring a shebang line the same way the
+   * Jenkins Shell build step does: if the script starts with {@code #!}, that interpreter is used;
+   * otherwise {@code /bin/sh -xe} is used as the default.
+   */
+  private static List<String> buildShellCommand(String setupScript, FilePath tempScript) {
+    if (setupScript.startsWith("#!")) {
+      int end = setupScript.indexOf('\n');
+      if (end < 0) end = setupScript.length();
+      String shebangLine = setupScript.substring(0, end).trim();
+      List<String> args = new ArrayList<>(Arrays.asList(Util.tokenize(shebangLine)));
+      args.set(0, args.get(0).substring(2));
+      args.add(tempScript.getRemote());
+      return args;
+    }
+    return List.of("/bin/sh", "-xe", tempScript.getRemote());
+  }
+
+  private static String shellQuote(String s) {
+    if (s.isEmpty()) {
+      return "''";
+    }
+    if (s.matches("[a-zA-Z0-9_./:=@-]+")) {
+      return s;
+    }
+    return "'" + s.replace("'", "'\\''") + "'";
+  }
+
+  private static FilePath resolveRunDirectory(FilePath workspace, String workDirValue) {
+    String trimmed = Util.fixNull(workDirValue).trim();
+    if (trimmed.isEmpty()) {
+      return workspace;
+    }
+    return workspace.child(trimmed);
+  }
+
+  /**
+   * Prevents one stream pump from closing the shared output handler while the other stream is still
+   * active. The Jenkins launcher may close stdout and stderr independently.
+   */
+  private static final class NonClosingSynchronizedOutputStream extends OutputStream {
+    private final OutputStream delegate;
+
+    NonClosingSynchronizedOutputStream(OutputStream delegate) {
+      this.delegate = delegate;
     }
 
-    private static void appendShebangAwarePreamble(
-            StringBuilder sb, String setupScript, Map<String, String> shellEnvironment) {
-        String normalizedSetupScript = Util.fixNull(setupScript);
-        if (normalizedSetupScript.startsWith("#!")) {
-            int end = normalizedSetupScript.indexOf('\n');
-            if (end < 0) {
-                end = normalizedSetupScript.length();
-            }
-            sb.append(normalizedSetupScript, 0, end).append('\n');
-            appendShellExports(sb, shellEnvironment);
-            if (end < normalizedSetupScript.length()) {
-                sb.append(normalizedSetupScript.substring(end + 1));
-                if (!normalizedSetupScript.endsWith("\n")) {
-                    sb.append('\n');
-                }
-            }
-            return;
-        }
-        appendShellExports(sb, shellEnvironment);
-        sb.append(normalizedSetupScript);
-        if (!normalizedSetupScript.isEmpty() && !normalizedSetupScript.endsWith("\n")) {
-            sb.append('\n');
-        }
+    @Override
+    public void write(int b) throws IOException {
+      synchronized (delegate) {
+        delegate.write(b);
+      }
     }
 
-    private static void appendShellExports(StringBuilder sb, Map<String, String> shellEnvironment) {
-        for (Map.Entry<String, String> entry : shellEnvironment.entrySet()) {
-            String key = entry.getKey();
-            if (key == null || key.isBlank()) {
-                continue;
-            }
-            sb.append("export ")
-                    .append(key)
-                    .append('=')
-                    .append(shellQuote(entry.getValue() == null ? "" : entry.getValue()))
-                    .append('\n');
-        }
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      synchronized (delegate) {
+        delegate.write(b, off, len);
+      }
     }
 
-    /**
-     * Writes the combined script to an agent-local temp area so the AI agent never sees it in the
-     * project workspace.
-     */
-    private static FilePath writeTempScript(FilePath workspace, String combinedScript)
-            throws IOException, InterruptedException {
-        FilePath tempDir = AiAgentTempFiles.tempRoot(workspace);
-        FilePath tempScript = tempDir.createTextTempFile("ai-agent-setup", ".sh", combinedScript);
-        tempScript.chmod(0755);
-        return tempScript;
+    @Override
+    public void flush() throws IOException {
+      synchronized (delegate) {
+        delegate.flush();
+      }
     }
 
-    /**
-     * Builds the shell command to run the combined script, honoring a shebang line the same way the
-     * Jenkins Shell build step does: if the script starts with {@code #!}, that interpreter is
-     * used; otherwise {@code /bin/sh -xe} is used as the default.
-     */
-    private static List<String> buildShellCommand(String setupScript, FilePath tempScript) {
-        if (setupScript.startsWith("#!")) {
-            int end = setupScript.indexOf('\n');
-            if (end < 0) end = setupScript.length();
-            String shebangLine = setupScript.substring(0, end).trim();
-            List<String> args = new ArrayList<>(Arrays.asList(Util.tokenize(shebangLine)));
-            args.set(0, args.get(0).substring(2));
-            args.add(tempScript.getRemote());
-            return args;
-        }
-        return List.of("/bin/sh", "-xe", tempScript.getRemote());
+    @Override
+    public void close() {}
+  }
+
+  private static final class AgentOutputHandler extends LineTransformationOutputStream {
+    private final OutputStream logger;
+    private final BufferedWriter rawWriter;
+    private final ExecutionRegistry.LiveExecution liveExecution;
+    private final boolean approvalsEnabled;
+    private final Duration approvalTimeout;
+    private final AiAgentLogFormat logFormat;
+    private final AtomicLong lineCounter = new AtomicLong();
+    private volatile Proc proc;
+    private volatile boolean deniedByApproval;
+
+    AgentOutputHandler(
+        OutputStream logger,
+        File rawLogFile,
+        ExecutionRegistry.LiveExecution liveExecution,
+        boolean approvalsEnabled,
+        Duration approvalTimeout,
+        AiAgentLogFormat logFormat)
+        throws IOException {
+      this.logger = logger;
+      this.rawWriter =
+          new BufferedWriter(
+              new OutputStreamWriter(
+                  Files.newOutputStream(rawLogFile.toPath()), StandardCharsets.UTF_8));
+      this.liveExecution = liveExecution;
+      this.approvalsEnabled = approvalsEnabled;
+      this.approvalTimeout = approvalTimeout;
+      this.logFormat = logFormat;
     }
 
-    private static String shellQuote(String s) {
-        if (s.isEmpty()) {
-            return "''";
-        }
-        if (s.matches("[a-zA-Z0-9_./:=@-]+")) {
-            return s;
-        }
-        return "'" + s.replace("'", "'\\''") + "'";
+    void attach(Proc proc) {
+      this.proc = proc;
     }
 
-    private static FilePath resolveRunDirectory(FilePath workspace, String workDirValue) {
-        String trimmed = Util.fixNull(workDirValue).trim();
-        if (trimmed.isEmpty()) {
-            return workspace;
-        }
-        return workspace.child(trimmed);
+    boolean wasDeniedByApproval() {
+      return deniedByApproval;
     }
 
-    /**
-     * Prevents one stream pump from closing the shared output handler while the other stream is
-     * still active. The Jenkins launcher may close stdout and stderr independently.
-     */
-    private static final class NonClosingSynchronizedOutputStream extends OutputStream {
-        private final OutputStream delegate;
+    @Override
+    protected synchronized void eol(byte[] b, int len) throws IOException {
+      String line = new String(b, 0, len, StandardCharsets.UTF_8);
+      if (line.endsWith("\r")) {
+        line = line.substring(0, line.length() - 1);
+      }
 
-        NonClosingSynchronizedOutputStream(OutputStream delegate) {
-            this.delegate = delegate;
+      logger.write(line.getBytes(StandardCharsets.UTF_8));
+      logger.write('\n');
+      logger.flush();
+
+      rawWriter.write(line);
+      rawWriter.newLine();
+      rawWriter.flush();
+
+      if (!approvalsEnabled) {
+        return;
+      }
+
+      long id = lineCounter.incrementAndGet();
+      AiAgentLogParser.ParsedLine parsedLine = AiAgentLogParser.parseLine(id, line, logFormat);
+      if (!parsedLine.isToolCall()) {
+        return;
+      }
+
+      ExecutionRegistry.PendingApproval pending =
+          liveExecution.createPendingApproval(
+              parsedLine.getToolCallIdOrGenerated(),
+              parsedLine.getToolName(),
+              parsedLine.getSummary());
+      logger.write(
+          ("[ai-agent] Approval required: "
+                  + pending.getToolName()
+                  + " ("
+                  + pending.getToolCallId()
+                  + ")\n")
+              .getBytes(StandardCharsets.UTF_8));
+      logger.flush();
+
+      ExecutionRegistry.ApprovalDecision decision =
+          liveExecution.awaitDecision(pending, approvalTimeout);
+      if (!decision.isApproved()) {
+        deniedByApproval = true;
+        logger.write(
+            ("[ai-agent] Approval denied: " + decision.getReason() + "\n")
+                .getBytes(StandardCharsets.UTF_8));
+        logger.flush();
+        Proc currentProc = this.proc;
+        if (currentProc != null) {
+          try {
+            currentProc.kill();
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
         }
-
-        @Override
-        public void write(int b) throws IOException {
-            synchronized (delegate) {
-                delegate.write(b);
-            }
-        }
-
-        @Override
-        public void write(byte[] b, int off, int len) throws IOException {
-            synchronized (delegate) {
-                delegate.write(b, off, len);
-            }
-        }
-
-        @Override
-        public void flush() throws IOException {
-            synchronized (delegate) {
-                delegate.flush();
-            }
-        }
-
-        @Override
-        public void close() {}
+      } else {
+        logger.write(
+            ("[ai-agent] Approval granted: " + pending.getToolName() + "\n")
+                .getBytes(StandardCharsets.UTF_8));
+        logger.flush();
+      }
     }
 
-    private static final class AgentOutputHandler extends LineTransformationOutputStream {
-        private final OutputStream logger;
-        private final BufferedWriter rawWriter;
-        private final ExecutionRegistry.LiveExecution liveExecution;
-        private final boolean approvalsEnabled;
-        private final Duration approvalTimeout;
-        private final AiAgentLogFormat logFormat;
-        private final AtomicLong lineCounter = new AtomicLong();
-        private volatile Proc proc;
-        private volatile boolean deniedByApproval;
-
-        AgentOutputHandler(
-                OutputStream logger,
-                File rawLogFile,
-                ExecutionRegistry.LiveExecution liveExecution,
-                boolean approvalsEnabled,
-                Duration approvalTimeout,
-                AiAgentLogFormat logFormat)
-                throws IOException {
-            this.logger = logger;
-            this.rawWriter =
-                    new BufferedWriter(
-                            new OutputStreamWriter(
-                                    Files.newOutputStream(rawLogFile.toPath()),
-                                    StandardCharsets.UTF_8));
-            this.liveExecution = liveExecution;
-            this.approvalsEnabled = approvalsEnabled;
-            this.approvalTimeout = approvalTimeout;
-            this.logFormat = logFormat;
-        }
-
-        void attach(Proc proc) {
-            this.proc = proc;
-        }
-
-        boolean wasDeniedByApproval() {
-            return deniedByApproval;
-        }
-
-        @Override
-        protected synchronized void eol(byte[] b, int len) throws IOException {
-            String line = new String(b, 0, len, StandardCharsets.UTF_8);
-            if (line.endsWith("\r")) {
-                line = line.substring(0, line.length() - 1);
-            }
-
-            logger.write(line.getBytes(StandardCharsets.UTF_8));
-            logger.write('\n');
-            logger.flush();
-
-            rawWriter.write(line);
-            rawWriter.newLine();
-            rawWriter.flush();
-
-            if (!approvalsEnabled) {
-                return;
-            }
-
-            long id = lineCounter.incrementAndGet();
-            AiAgentLogParser.ParsedLine parsedLine =
-                    AiAgentLogParser.parseLine(id, line, logFormat);
-            if (!parsedLine.isToolCall()) {
-                return;
-            }
-
-            ExecutionRegistry.PendingApproval pending =
-                    liveExecution.createPendingApproval(
-                            parsedLine.getToolCallIdOrGenerated(),
-                            parsedLine.getToolName(),
-                            parsedLine.getSummary());
-            logger.write(
-                    ("[ai-agent] Approval required: "
-                                    + pending.getToolName()
-                                    + " ("
-                                    + pending.getToolCallId()
-                                    + ")\n")
-                            .getBytes(StandardCharsets.UTF_8));
-            logger.flush();
-
-            ExecutionRegistry.ApprovalDecision decision =
-                    liveExecution.awaitDecision(pending, approvalTimeout);
-            if (!decision.isApproved()) {
-                deniedByApproval = true;
-                logger.write(
-                        ("[ai-agent] Approval denied: " + decision.getReason() + "\n")
-                                .getBytes(StandardCharsets.UTF_8));
-                logger.flush();
-                Proc currentProc = this.proc;
-                if (currentProc != null) {
-                    try {
-                        currentProc.kill();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
-                }
-            } else {
-                logger.write(
-                        ("[ai-agent] Approval granted: " + pending.getToolName() + "\n")
-                                .getBytes(StandardCharsets.UTF_8));
-                logger.flush();
-            }
-        }
-
-        @Override
-        public synchronized void close() throws IOException {
-            super.close();
-            rawWriter.close();
-        }
+    @Override
+    public synchronized void close() throws IOException {
+      super.close();
+      rawWriter.close();
     }
+  }
 }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -112,15 +112,17 @@ final class AiAgentExecutor {
 
         boolean needsShellEnvironmentBootstrap =
                 launcher.isUnix() && !executionCustomization.getEnvironment().isEmpty();
+        boolean forceUnixShell = config.isDisableInteractive() && launcher.isUnix();
         List<String> command;
         FilePath tempSetupScript = null;
-        if ((!setupScript.isEmpty() && launcher.isUnix()) || needsShellEnvironmentBootstrap) {
+        if ((!setupScript.isEmpty() && launcher.isUnix()) || needsShellEnvironmentBootstrap || forceUnixShell) {
             String combinedScript =
                     buildCombinedScript(
                             setupScript,
                             executionCustomization.getEnvironment(),
                             agentCommand,
-                            commandOverride);
+                            commandOverride,
+                            config.isDisableInteractive());
             tempSetupScript = writeTempScript(workspace, combinedScript);
             command = buildShellCommand(combinedScript, tempSetupScript);
         } else if (!commandOverride.isEmpty()) {
@@ -128,8 +130,14 @@ final class AiAgentExecutor {
                 // Use a non-login shell so injected HOME/USERPROFILE are not overridden.
                 command = List.of("/bin/sh", "-c", commandOverride);
             } else {
-                command = List.of("cmd", "/c", commandOverride);
+                String cmd = commandOverride;
+                if (config.isDisableInteractive() && !cmd.toUpperCase().contains("< NUL")) {
+                    cmd = cmd.endsWith("\n") ? cmd.substring(0, cmd.length() - 1) + " < NUL\n" : cmd + " < NUL";
+                }
+                command = List.of("cmd", "/c", cmd);
             }
+        } else if (config.isDisableInteractive()) {
+            command = List.of("cmd", "/c", AiAgentCommandFactory.commandAsString(agentCommand) + " < NUL");
         } else {
             command = agentCommand;
         }
@@ -206,26 +214,30 @@ final class AiAgentExecutor {
         return exitCode;
     }
 
-    /**
-     * Builds the combined script that runs setup/bootstrap preamble and then launches the final
-     * agent command in the same shell session, so exported variables flow through.
-     */
     private static String buildCombinedScript(
             String setupScript,
             Map<String, String> shellEnvironment,
             List<String> agentCommand,
-            String commandOverride) {
+            String commandOverride,
+            boolean disableInteractive) {
         StringBuilder sb = new StringBuilder();
         appendShebangAwarePreamble(sb, setupScript, shellEnvironment);
         if (!commandOverride.isEmpty()) {
-            sb.append(commandOverride);
-            if (!commandOverride.endsWith("\n")) {
+            String cmd = commandOverride;
+            if (disableInteractive && !cmd.contains("< /dev/null")) {
+                cmd = cmd.endsWith("\n") ? cmd.substring(0, cmd.length() - 1) + " < /dev/null\n" : cmd + " < /dev/null";
+            }
+            sb.append(cmd);
+            if (!cmd.endsWith("\n")) {
                 sb.append('\n');
             }
         } else {
             sb.append("exec");
             for (String token : agentCommand) {
                 sb.append(' ').append(shellQuote(token));
+            }
+            if (disableInteractive) {
+                sb.append(" < /dev/null");
             }
             sb.append('\n');
         }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.aiagentjob;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -10,6 +11,9 @@ import hudson.Util;
 import hudson.console.LineTransformationOutputStream;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+
+import org.jenkinsci.plugins.plaincredentials.StringCredentials;
+
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
@@ -25,456 +29,463 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
-import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 /**
  * Runs the AI agent subprocess, wires stdout/stderr to the Jenkins build log and the raw JSONL log
  * file, and handles the approval-gate flow when approvals are enabled.
  */
 final class AiAgentExecutor {
-  private AiAgentExecutor() {}
+    private AiAgentExecutor() {}
 
-  static int execute(
-      Run<?, ?> run,
-      FilePath workspace,
-      EnvVars stepEnv,
-      Launcher launcher,
-      TaskListener listener,
-      AiAgentConfiguration config,
-      AiAgentRunAction action)
-      throws IOException, InterruptedException {
-    EnvVars env = new EnvVars(stepEnv);
+    static int execute(
+            Run<?, ?> run,
+            FilePath workspace,
+            EnvVars stepEnv,
+            Launcher launcher,
+            TaskListener listener,
+            AiAgentConfiguration config,
+            AiAgentRunAction action)
+            throws IOException, InterruptedException {
+        EnvVars env = new EnvVars(stepEnv);
 
-    String prompt = Util.replaceMacro(Util.fixNull(config.getPrompt()), env);
-    String model = Util.replaceMacro(Util.fixNull(config.getModel()), env);
-    String workDirValue = Util.replaceMacro(Util.fixNull(config.getWorkingDirectory()), env);
-    String commandOverride = Util.fixNull(config.getCommandOverride()).trim();
+        String prompt = Util.replaceMacro(Util.fixNull(config.getPrompt()), env);
+        String model = Util.replaceMacro(Util.fixNull(config.getModel()), env);
+        String workDirValue = Util.replaceMacro(Util.fixNull(config.getWorkingDirectory()), env);
+        String commandOverride = Util.fixNull(config.getCommandOverride()).trim();
 
-    FilePath runDirectory = resolveRunDirectory(workspace, workDirValue);
-    runDirectory.mkdirs();
+        FilePath runDirectory = resolveRunDirectory(workspace, workDirValue);
+        runDirectory.mkdirs();
 
-    EnvVars procEnv = new EnvVars(env);
-    procEnv.putAll(
-        new LinkedHashMap<>(
-            AiAgentCommandFactory.parseEnvironmentVariables(config.getEnvironmentVariables())));
+        EnvVars procEnv = new EnvVars(env);
+        procEnv.putAll(
+                new LinkedHashMap<>(
+                        AiAgentCommandFactory.parseEnvironmentVariables(
+                                config.getEnvironmentVariables())));
 
-    // Inject API key from Jenkins Credentials if configured
-    String credentialsId = Util.fixEmptyAndTrim(config.getApiCredentialsId());
-    if (credentialsId != null) {
-      StringCredentials cred =
-          CredentialsProvider.findCredentialById(
-              credentialsId,
-              StringCredentials.class,
-              run,
-              Collections.<DomainRequirement>emptyList());
-      if (cred != null) {
-        String envVarName = config.getEffectiveApiKeyEnvVar();
-        procEnv.put(envVarName, cred.getSecret().getPlainText());
-        listener
-            .getLogger()
-            .println(
-                "[ai-agent] API key injected as "
-                    + envVarName
-                    + " from credential '"
-                    + credentialsId
-                    + "'");
-      } else {
-        listener
-            .getLogger()
-            .println(
-                "[ai-agent] WARNING: Credential '"
-                    + credentialsId
-                    + "' not found. Agent may fail to authenticate.");
-      }
-    }
-
-    procEnv.put("AI_AGENT_PROMPT", prompt);
-    procEnv.put("AI_AGENT_MODEL", model);
-
-    String setupScript = Util.fixNull(config.getSetupScript()).trim();
-    if (!setupScript.isEmpty() && !launcher.isUnix()) {
-      throw new IOException(
-          "Setup script is currently supported only on Unix agents. "
-              + "Use Command override for Windows nodes.");
-    }
-    AiAgentExecutionCustomization executionCustomization =
-        config.getAgent().prepareExecution(config, workspace, listener);
-    procEnv.putAll(executionCustomization.getEnvironment());
-
-    List<String> agentCommand;
-    if (!commandOverride.isEmpty()) {
-      agentCommand = List.of(commandOverride);
-    } else {
-      agentCommand = AiAgentCommandFactory.buildDefaultCommand(config, prompt);
-    }
-
-    boolean needsShellEnvironmentBootstrap =
-        launcher.isUnix() && !executionCustomization.getEnvironment().isEmpty();
-    boolean forceUnixShell = config.isDisableInteractive() && launcher.isUnix();
-    List<String> command;
-    FilePath tempSetupScript = null;
-    if ((!setupScript.isEmpty() && launcher.isUnix())
-        || needsShellEnvironmentBootstrap
-        || forceUnixShell) {
-      String combinedScript =
-          buildCombinedScript(
-              setupScript,
-              executionCustomization.getEnvironment(),
-              agentCommand,
-              commandOverride,
-              config.isDisableInteractive());
-      tempSetupScript = writeTempScript(workspace, combinedScript);
-      command = buildShellCommand(combinedScript, tempSetupScript);
-    } else if (!commandOverride.isEmpty()) {
-      if (launcher.isUnix()) {
-        // Use a non-login shell so injected HOME/USERPROFILE are not overridden.
-        command = List.of("/bin/sh", "-c", commandOverride);
-      } else {
-        String cmd = commandOverride;
-        if (config.isDisableInteractive() && !cmd.toUpperCase().contains("< NUL")) {
-          cmd =
-              cmd.endsWith("\n") ? cmd.substring(0, cmd.length() - 1) + " < NUL\n" : cmd + " < NUL";
+        // Inject API key from Jenkins Credentials if configured
+        String credentialsId = Util.fixEmptyAndTrim(config.getApiCredentialsId());
+        if (credentialsId != null) {
+            StringCredentials cred =
+                    CredentialsProvider.findCredentialById(
+                            credentialsId,
+                            StringCredentials.class,
+                            run,
+                            Collections.<DomainRequirement>emptyList());
+            if (cred != null) {
+                String envVarName = config.getEffectiveApiKeyEnvVar();
+                procEnv.put(envVarName, cred.getSecret().getPlainText());
+                listener.getLogger()
+                        .println(
+                                "[ai-agent] API key injected as "
+                                        + envVarName
+                                        + " from credential '"
+                                        + credentialsId
+                                        + "'");
+            } else {
+                listener.getLogger()
+                        .println(
+                                "[ai-agent] WARNING: Credential '"
+                                        + credentialsId
+                                        + "' not found. Agent may fail to authenticate.");
+            }
         }
-        command = List.of("cmd", "/c", cmd);
-      }
-    } else if (config.isDisableInteractive()) {
-      command =
-          List.of("cmd", "/c", AiAgentCommandFactory.commandAsString(agentCommand) + " < NUL");
-    } else {
-      command = agentCommand;
-    }
 
-    if (!setupScript.isEmpty()) {
-      listener.getLogger().println("[ai-agent] Setup script will run before the agent.");
-    }
+        procEnv.put("AI_AGENT_PROMPT", prompt);
+        procEnv.put("AI_AGENT_MODEL", model);
 
-    String commandLine =
-        commandOverride.isEmpty()
-            ? AiAgentCommandFactory.commandAsString(agentCommand)
-            : commandOverride;
-    int invocationId =
-        action.markStarted(
-            config.getAgent().getDescriptor().getDisplayName(),
-            prompt,
-            model,
-            commandLine,
-            config.isYoloMode(),
-            config.isRequireApprovals());
+        String setupScript = Util.fixNull(config.getSetupScript()).trim();
+        if (!setupScript.isEmpty() && !launcher.isUnix()) {
+            throw new IOException(
+                    "Setup script is currently supported only on Unix agents. "
+                            + "Use Command override for Windows nodes.");
+        }
+        AiAgentExecutionCustomization executionCustomization =
+                config.getAgent().prepareExecution(config, workspace, listener);
+        procEnv.putAll(executionCustomization.getEnvironment());
 
-    File rawLogFile = action.getRawLogFile(invocationId);
-    Files.deleteIfExists(rawLogFile.toPath());
+        List<String> agentCommand;
+        if (!commandOverride.isEmpty()) {
+            agentCommand = List.of(commandOverride);
+        } else {
+            agentCommand = AiAgentCommandFactory.buildDefaultCommand(config, prompt);
+        }
 
-    ExecutionRegistry.LiveExecution liveExecution = ExecutionRegistry.register(run, invocationId);
-    Duration approvalTimeout = Duration.ofSeconds(Math.max(1, config.getApprovalTimeoutSeconds()));
+        boolean needsShellEnvironmentBootstrap =
+                launcher.isUnix() && !executionCustomization.getEnvironment().isEmpty();
+        boolean forceUnixShell = config.isDisableInteractive() && launcher.isUnix();
+        List<String> command;
+        FilePath tempSetupScript = null;
+        if ((!setupScript.isEmpty() && launcher.isUnix())
+                || needsShellEnvironmentBootstrap
+                || forceUnixShell) {
+            String combinedScript =
+                    buildCombinedScript(
+                            setupScript,
+                            executionCustomization.getEnvironment(),
+                            agentCommand,
+                            commandOverride,
+                            config.isDisableInteractive());
+            tempSetupScript = writeTempScript(workspace, combinedScript);
+            command = buildShellCommand(combinedScript, tempSetupScript);
+        } else if (!commandOverride.isEmpty()) {
+            if (launcher.isUnix()) {
+                // Use a non-login shell so injected HOME/USERPROFILE are not overridden.
+                command = List.of("/bin/sh", "-c", commandOverride);
+            } else {
+                String cmd = commandOverride;
+                if (config.isDisableInteractive() && !cmd.toUpperCase().contains("< NUL")) {
+                    cmd =
+                            cmd.endsWith("\n")
+                                    ? cmd.substring(0, cmd.length() - 1) + " < NUL\n"
+                                    : cmd + " < NUL";
+                }
+                command = List.of("cmd", "/c", cmd);
+            }
+        } else if (config.isDisableInteractive()) {
+            command =
+                    List.of(
+                            "cmd",
+                            "/c",
+                            AiAgentCommandFactory.commandAsString(agentCommand) + " < NUL");
+        } else {
+            command = agentCommand;
+        }
 
-    AgentOutputHandler outputHandler =
-        new AgentOutputHandler(
-            listener.getLogger(),
-            rawLogFile,
-            liveExecution,
-            config.isRequireApprovals() && !config.isYoloMode(),
-            approvalTimeout,
-            config.getAgent().getLogFormat());
-    OutputStream stdoutSink = new NonClosingSynchronizedOutputStream(outputHandler);
-    OutputStream stderrSink = new NonClosingSynchronizedOutputStream(outputHandler);
+        if (!setupScript.isEmpty()) {
+            listener.getLogger().println("[ai-agent] Setup script will run before the agent.");
+        }
 
-    int exitCode;
-    try {
-      Proc proc =
-          launcher
-              .launch()
-              .cmds(command)
-              .pwd(runDirectory)
-              .envs(procEnv)
-              .stdout(stdoutSink)
-              .stderr(stderrSink)
-              .quiet(true)
-              .start();
-      outputHandler.attach(proc);
-      exitCode = proc.join();
-    } finally {
-      outputHandler.close();
-      ExecutionRegistry.unregister(run, invocationId);
-      if (tempSetupScript != null) {
+        String commandLine =
+                commandOverride.isEmpty()
+                        ? AiAgentCommandFactory.commandAsString(agentCommand)
+                        : commandOverride;
+        int invocationId =
+                action.markStarted(
+                        config.getAgent().getDescriptor().getDisplayName(),
+                        prompt,
+                        model,
+                        commandLine,
+                        config.isYoloMode(),
+                        config.isRequireApprovals());
+
+        File rawLogFile = action.getRawLogFile(invocationId);
+        Files.deleteIfExists(rawLogFile.toPath());
+
+        ExecutionRegistry.LiveExecution liveExecution =
+                ExecutionRegistry.register(run, invocationId);
+        Duration approvalTimeout =
+                Duration.ofSeconds(Math.max(1, config.getApprovalTimeoutSeconds()));
+
+        AgentOutputHandler outputHandler =
+                new AgentOutputHandler(
+                        listener.getLogger(),
+                        rawLogFile,
+                        liveExecution,
+                        config.isRequireApprovals() && !config.isYoloMode(),
+                        approvalTimeout,
+                        config.getAgent().getLogFormat());
+        OutputStream stdoutSink = new NonClosingSynchronizedOutputStream(outputHandler);
+        OutputStream stderrSink = new NonClosingSynchronizedOutputStream(outputHandler);
+
+        int exitCode;
         try {
-          tempSetupScript.delete();
-        } catch (IOException e) {
-          listener
-              .getLogger()
-              .println("[ai-agent] Warning: could not delete temp script: " + e.getMessage());
+            Proc proc =
+                    launcher.launch()
+                            .cmds(command)
+                            .pwd(runDirectory)
+                            .envs(procEnv)
+                            .stdout(stdoutSink)
+                            .stderr(stderrSink)
+                            .quiet(true)
+                            .start();
+            outputHandler.attach(proc);
+            exitCode = proc.join();
+        } finally {
+            outputHandler.close();
+            ExecutionRegistry.unregister(run, invocationId);
+            if (tempSetupScript != null) {
+                try {
+                    tempSetupScript.delete();
+                } catch (IOException e) {
+                    listener.getLogger()
+                            .println(
+                                    "[ai-agent] Warning: could not delete temp script: "
+                                            + e.getMessage());
+                }
+            }
+            executionCustomization.cleanup(listener);
         }
-      }
-      executionCustomization.cleanup(listener);
-    }
 
-    if (outputHandler.wasDeniedByApproval()) {
-      exitCode = 1;
-    }
-    action.markCompleted(invocationId, exitCode);
-    return exitCode;
-  }
-
-  private static String buildCombinedScript(
-      String setupScript,
-      Map<String, String> shellEnvironment,
-      List<String> agentCommand,
-      String commandOverride,
-      boolean disableInteractive) {
-    StringBuilder sb = new StringBuilder();
-    appendShebangAwarePreamble(sb, setupScript, shellEnvironment);
-    if (!commandOverride.isEmpty()) {
-      String cmd = commandOverride;
-      if (disableInteractive && !cmd.contains("< /dev/null")) {
-        cmd =
-            cmd.endsWith("\n")
-                ? cmd.substring(0, cmd.length() - 1) + " < /dev/null\n"
-                : cmd + " < /dev/null";
-      }
-      sb.append(cmd);
-      if (!cmd.endsWith("\n")) {
-        sb.append('\n');
-      }
-    } else {
-      sb.append("exec");
-      for (String token : agentCommand) {
-        sb.append(' ').append(shellQuote(token));
-      }
-      if (disableInteractive) {
-        sb.append(" < /dev/null");
-      }
-      sb.append('\n');
-    }
-    return sb.toString();
-  }
-
-  private static void appendShebangAwarePreamble(
-      StringBuilder sb, String setupScript, Map<String, String> shellEnvironment) {
-    String normalizedSetupScript = Util.fixNull(setupScript);
-    if (normalizedSetupScript.startsWith("#!")) {
-      int end = normalizedSetupScript.indexOf('\n');
-      if (end < 0) {
-        end = normalizedSetupScript.length();
-      }
-      sb.append(normalizedSetupScript, 0, end).append('\n');
-      appendShellExports(sb, shellEnvironment);
-      if (end < normalizedSetupScript.length()) {
-        sb.append(normalizedSetupScript.substring(end + 1));
-        if (!normalizedSetupScript.endsWith("\n")) {
-          sb.append('\n');
+        if (outputHandler.wasDeniedByApproval()) {
+            exitCode = 1;
         }
-      }
-      return;
-    }
-    appendShellExports(sb, shellEnvironment);
-    sb.append(normalizedSetupScript);
-    if (!normalizedSetupScript.isEmpty() && !normalizedSetupScript.endsWith("\n")) {
-      sb.append('\n');
-    }
-  }
-
-  private static void appendShellExports(StringBuilder sb, Map<String, String> shellEnvironment) {
-    for (Map.Entry<String, String> entry : shellEnvironment.entrySet()) {
-      String key = entry.getKey();
-      if (key == null || key.isBlank()) {
-        continue;
-      }
-      sb.append("export ")
-          .append(key)
-          .append('=')
-          .append(shellQuote(entry.getValue() == null ? "" : entry.getValue()))
-          .append('\n');
-    }
-  }
-
-  /**
-   * Writes the combined script to an agent-local temp area so the AI agent never sees it in the
-   * project workspace.
-   */
-  private static FilePath writeTempScript(FilePath workspace, String combinedScript)
-      throws IOException, InterruptedException {
-    FilePath tempDir = AiAgentTempFiles.tempRoot(workspace);
-    FilePath tempScript = tempDir.createTextTempFile("ai-agent-setup", ".sh", combinedScript);
-    tempScript.chmod(0755);
-    return tempScript;
-  }
-
-  /**
-   * Builds the shell command to run the combined script, honoring a shebang line the same way the
-   * Jenkins Shell build step does: if the script starts with {@code #!}, that interpreter is used;
-   * otherwise {@code /bin/sh -xe} is used as the default.
-   */
-  private static List<String> buildShellCommand(String setupScript, FilePath tempScript) {
-    if (setupScript.startsWith("#!")) {
-      int end = setupScript.indexOf('\n');
-      if (end < 0) end = setupScript.length();
-      String shebangLine = setupScript.substring(0, end).trim();
-      List<String> args = new ArrayList<>(Arrays.asList(Util.tokenize(shebangLine)));
-      args.set(0, args.get(0).substring(2));
-      args.add(tempScript.getRemote());
-      return args;
-    }
-    return List.of("/bin/sh", "-xe", tempScript.getRemote());
-  }
-
-  private static String shellQuote(String s) {
-    if (s.isEmpty()) {
-      return "''";
-    }
-    if (s.matches("[a-zA-Z0-9_./:=@-]+")) {
-      return s;
-    }
-    return "'" + s.replace("'", "'\\''") + "'";
-  }
-
-  private static FilePath resolveRunDirectory(FilePath workspace, String workDirValue) {
-    String trimmed = Util.fixNull(workDirValue).trim();
-    if (trimmed.isEmpty()) {
-      return workspace;
-    }
-    return workspace.child(trimmed);
-  }
-
-  /**
-   * Prevents one stream pump from closing the shared output handler while the other stream is still
-   * active. The Jenkins launcher may close stdout and stderr independently.
-   */
-  private static final class NonClosingSynchronizedOutputStream extends OutputStream {
-    private final OutputStream delegate;
-
-    NonClosingSynchronizedOutputStream(OutputStream delegate) {
-      this.delegate = delegate;
+        action.markCompleted(invocationId, exitCode);
+        return exitCode;
     }
 
-    @Override
-    public void write(int b) throws IOException {
-      synchronized (delegate) {
-        delegate.write(b);
-      }
-    }
-
-    @Override
-    public void write(byte[] b, int off, int len) throws IOException {
-      synchronized (delegate) {
-        delegate.write(b, off, len);
-      }
-    }
-
-    @Override
-    public void flush() throws IOException {
-      synchronized (delegate) {
-        delegate.flush();
-      }
-    }
-
-    @Override
-    public void close() {}
-  }
-
-  private static final class AgentOutputHandler extends LineTransformationOutputStream {
-    private final OutputStream logger;
-    private final BufferedWriter rawWriter;
-    private final ExecutionRegistry.LiveExecution liveExecution;
-    private final boolean approvalsEnabled;
-    private final Duration approvalTimeout;
-    private final AiAgentLogFormat logFormat;
-    private final AtomicLong lineCounter = new AtomicLong();
-    private volatile Proc proc;
-    private volatile boolean deniedByApproval;
-
-    AgentOutputHandler(
-        OutputStream logger,
-        File rawLogFile,
-        ExecutionRegistry.LiveExecution liveExecution,
-        boolean approvalsEnabled,
-        Duration approvalTimeout,
-        AiAgentLogFormat logFormat)
-        throws IOException {
-      this.logger = logger;
-      this.rawWriter =
-          new BufferedWriter(
-              new OutputStreamWriter(
-                  Files.newOutputStream(rawLogFile.toPath()), StandardCharsets.UTF_8));
-      this.liveExecution = liveExecution;
-      this.approvalsEnabled = approvalsEnabled;
-      this.approvalTimeout = approvalTimeout;
-      this.logFormat = logFormat;
-    }
-
-    void attach(Proc proc) {
-      this.proc = proc;
-    }
-
-    boolean wasDeniedByApproval() {
-      return deniedByApproval;
-    }
-
-    @Override
-    protected synchronized void eol(byte[] b, int len) throws IOException {
-      String line = new String(b, 0, len, StandardCharsets.UTF_8);
-      if (line.endsWith("\r")) {
-        line = line.substring(0, line.length() - 1);
-      }
-
-      logger.write(line.getBytes(StandardCharsets.UTF_8));
-      logger.write('\n');
-      logger.flush();
-
-      rawWriter.write(line);
-      rawWriter.newLine();
-      rawWriter.flush();
-
-      if (!approvalsEnabled) {
-        return;
-      }
-
-      long id = lineCounter.incrementAndGet();
-      AiAgentLogParser.ParsedLine parsedLine = AiAgentLogParser.parseLine(id, line, logFormat);
-      if (!parsedLine.isToolCall()) {
-        return;
-      }
-
-      ExecutionRegistry.PendingApproval pending =
-          liveExecution.createPendingApproval(
-              parsedLine.getToolCallIdOrGenerated(),
-              parsedLine.getToolName(),
-              parsedLine.getSummary());
-      logger.write(
-          ("[ai-agent] Approval required: "
-                  + pending.getToolName()
-                  + " ("
-                  + pending.getToolCallId()
-                  + ")\n")
-              .getBytes(StandardCharsets.UTF_8));
-      logger.flush();
-
-      ExecutionRegistry.ApprovalDecision decision =
-          liveExecution.awaitDecision(pending, approvalTimeout);
-      if (!decision.isApproved()) {
-        deniedByApproval = true;
-        logger.write(
-            ("[ai-agent] Approval denied: " + decision.getReason() + "\n")
-                .getBytes(StandardCharsets.UTF_8));
-        logger.flush();
-        Proc currentProc = this.proc;
-        if (currentProc != null) {
-          try {
-            currentProc.kill();
-          } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-          }
+    private static String buildCombinedScript(
+            String setupScript,
+            Map<String, String> shellEnvironment,
+            List<String> agentCommand,
+            String commandOverride,
+            boolean disableInteractive) {
+        StringBuilder sb = new StringBuilder();
+        appendShebangAwarePreamble(sb, setupScript, shellEnvironment);
+        if (!commandOverride.isEmpty()) {
+            String cmd = commandOverride;
+            if (disableInteractive && !cmd.contains("< /dev/null")) {
+                cmd =
+                        cmd.endsWith("\n")
+                                ? cmd.substring(0, cmd.length() - 1) + " < /dev/null\n"
+                                : cmd + " < /dev/null";
+            }
+            sb.append(cmd);
+            if (!cmd.endsWith("\n")) {
+                sb.append('\n');
+            }
+        } else {
+            sb.append("exec");
+            for (String token : agentCommand) {
+                sb.append(' ').append(shellQuote(token));
+            }
+            if (disableInteractive) {
+                sb.append(" < /dev/null");
+            }
+            sb.append('\n');
         }
-      } else {
-        logger.write(
-            ("[ai-agent] Approval granted: " + pending.getToolName() + "\n")
-                .getBytes(StandardCharsets.UTF_8));
-        logger.flush();
-      }
+        return sb.toString();
     }
 
-    @Override
-    public synchronized void close() throws IOException {
-      super.close();
-      rawWriter.close();
+    private static void appendShebangAwarePreamble(
+            StringBuilder sb, String setupScript, Map<String, String> shellEnvironment) {
+        String normalizedSetupScript = Util.fixNull(setupScript);
+        if (normalizedSetupScript.startsWith("#!")) {
+            int end = normalizedSetupScript.indexOf('\n');
+            if (end < 0) {
+                end = normalizedSetupScript.length();
+            }
+            sb.append(normalizedSetupScript, 0, end).append('\n');
+            appendShellExports(sb, shellEnvironment);
+            if (end < normalizedSetupScript.length()) {
+                sb.append(normalizedSetupScript.substring(end + 1));
+                if (!normalizedSetupScript.endsWith("\n")) {
+                    sb.append('\n');
+                }
+            }
+            return;
+        }
+        appendShellExports(sb, shellEnvironment);
+        sb.append(normalizedSetupScript);
+        if (!normalizedSetupScript.isEmpty() && !normalizedSetupScript.endsWith("\n")) {
+            sb.append('\n');
+        }
     }
-  }
+
+    private static void appendShellExports(StringBuilder sb, Map<String, String> shellEnvironment) {
+        for (Map.Entry<String, String> entry : shellEnvironment.entrySet()) {
+            String key = entry.getKey();
+            if (key == null || key.isBlank()) {
+                continue;
+            }
+            sb.append("export ")
+                    .append(key)
+                    .append('=')
+                    .append(shellQuote(entry.getValue() == null ? "" : entry.getValue()))
+                    .append('\n');
+        }
+    }
+
+    /**
+     * Writes the combined script to an agent-local temp area so the AI agent never sees it in the
+     * project workspace.
+     */
+    private static FilePath writeTempScript(FilePath workspace, String combinedScript)
+            throws IOException, InterruptedException {
+        FilePath tempDir = AiAgentTempFiles.tempRoot(workspace);
+        FilePath tempScript = tempDir.createTextTempFile("ai-agent-setup", ".sh", combinedScript);
+        tempScript.chmod(0755);
+        return tempScript;
+    }
+
+    /**
+     * Builds the shell command to run the combined script, honoring a shebang line the same way the
+     * Jenkins Shell build step does: if the script starts with {@code #!}, that interpreter is
+     * used; otherwise {@code /bin/sh -xe} is used as the default.
+     */
+    private static List<String> buildShellCommand(String setupScript, FilePath tempScript) {
+        if (setupScript.startsWith("#!")) {
+            int end = setupScript.indexOf('\n');
+            if (end < 0) end = setupScript.length();
+            String shebangLine = setupScript.substring(0, end).trim();
+            List<String> args = new ArrayList<>(Arrays.asList(Util.tokenize(shebangLine)));
+            args.set(0, args.get(0).substring(2));
+            args.add(tempScript.getRemote());
+            return args;
+        }
+        return List.of("/bin/sh", "-xe", tempScript.getRemote());
+    }
+
+    private static String shellQuote(String s) {
+        if (s.isEmpty()) {
+            return "''";
+        }
+        if (s.matches("[a-zA-Z0-9_./:=@-]+")) {
+            return s;
+        }
+        return "'" + s.replace("'", "'\\''") + "'";
+    }
+
+    private static FilePath resolveRunDirectory(FilePath workspace, String workDirValue) {
+        String trimmed = Util.fixNull(workDirValue).trim();
+        if (trimmed.isEmpty()) {
+            return workspace;
+        }
+        return workspace.child(trimmed);
+    }
+
+    /**
+     * Prevents one stream pump from closing the shared output handler while the other stream is
+     * still active. The Jenkins launcher may close stdout and stderr independently.
+     */
+    private static final class NonClosingSynchronizedOutputStream extends OutputStream {
+        private final OutputStream delegate;
+
+        NonClosingSynchronizedOutputStream(OutputStream delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            synchronized (delegate) {
+                delegate.write(b);
+            }
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+            synchronized (delegate) {
+                delegate.write(b, off, len);
+            }
+        }
+
+        @Override
+        public void flush() throws IOException {
+            synchronized (delegate) {
+                delegate.flush();
+            }
+        }
+
+        @Override
+        public void close() {}
+    }
+
+    private static final class AgentOutputHandler extends LineTransformationOutputStream {
+        private final OutputStream logger;
+        private final BufferedWriter rawWriter;
+        private final ExecutionRegistry.LiveExecution liveExecution;
+        private final boolean approvalsEnabled;
+        private final Duration approvalTimeout;
+        private final AiAgentLogFormat logFormat;
+        private final AtomicLong lineCounter = new AtomicLong();
+        private volatile Proc proc;
+        private volatile boolean deniedByApproval;
+
+        AgentOutputHandler(
+                OutputStream logger,
+                File rawLogFile,
+                ExecutionRegistry.LiveExecution liveExecution,
+                boolean approvalsEnabled,
+                Duration approvalTimeout,
+                AiAgentLogFormat logFormat)
+                throws IOException {
+            this.logger = logger;
+            this.rawWriter =
+                    new BufferedWriter(
+                            new OutputStreamWriter(
+                                    Files.newOutputStream(rawLogFile.toPath()),
+                                    StandardCharsets.UTF_8));
+            this.liveExecution = liveExecution;
+            this.approvalsEnabled = approvalsEnabled;
+            this.approvalTimeout = approvalTimeout;
+            this.logFormat = logFormat;
+        }
+
+        void attach(Proc proc) {
+            this.proc = proc;
+        }
+
+        boolean wasDeniedByApproval() {
+            return deniedByApproval;
+        }
+
+        @Override
+        protected synchronized void eol(byte[] b, int len) throws IOException {
+            String line = new String(b, 0, len, StandardCharsets.UTF_8);
+            if (line.endsWith("\r")) {
+                line = line.substring(0, line.length() - 1);
+            }
+
+            logger.write(line.getBytes(StandardCharsets.UTF_8));
+            logger.write('\n');
+            logger.flush();
+
+            rawWriter.write(line);
+            rawWriter.newLine();
+            rawWriter.flush();
+
+            if (!approvalsEnabled) {
+                return;
+            }
+
+            long id = lineCounter.incrementAndGet();
+            AiAgentLogParser.ParsedLine parsedLine =
+                    AiAgentLogParser.parseLine(id, line, logFormat);
+            if (!parsedLine.isToolCall()) {
+                return;
+            }
+
+            ExecutionRegistry.PendingApproval pending =
+                    liveExecution.createPendingApproval(
+                            parsedLine.getToolCallIdOrGenerated(),
+                            parsedLine.getToolName(),
+                            parsedLine.getSummary());
+            logger.write(
+                    ("[ai-agent] Approval required: "
+                                    + pending.getToolName()
+                                    + " ("
+                                    + pending.getToolCallId()
+                                    + ")\n")
+                            .getBytes(StandardCharsets.UTF_8));
+            logger.flush();
+
+            ExecutionRegistry.ApprovalDecision decision =
+                    liveExecution.awaitDecision(pending, approvalTimeout);
+            if (!decision.isApproved()) {
+                deniedByApproval = true;
+                logger.write(
+                        ("[ai-agent] Approval denied: " + decision.getReason() + "\n")
+                                .getBytes(StandardCharsets.UTF_8));
+                logger.flush();
+                Proc currentProc = this.proc;
+                if (currentProc != null) {
+                    try {
+                        currentProc.kill();
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }
+            } else {
+                logger.write(
+                        ("[ai-agent] Approval granted: " + pending.getToolName() + "\n")
+                                .getBytes(StandardCharsets.UTF_8));
+                logger.flush();
+            }
+        }
+
+        @Override
+        public synchronized void close() throws IOException {
+            super.close();
+            rawWriter.close();
+        }
+    }
 }

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly
@@ -18,6 +18,10 @@
     <f:checkbox />
   </f:entry>
 
+  <f:entry title="Disable interactive mode" field="disableInteractive" description="Provides an empty stdin to avoid the agent getting blocked waiting for user input.">
+    <f:checkbox />
+  </f:entry>
+
   <f:optionalBlock inline="true" title="Require manual approvals" field="requireApprovals">
     <f:entry title="Approval timeout (seconds)" field="approvalTimeoutSeconds" description="Only used when manual approvals are enabled.">
       <f:number min="1" step="1" />

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuilderConfigRoundTripTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuilderConfigRoundTripTest.java
@@ -39,6 +39,7 @@ class AiAgentBuilderConfigRoundTripTest {
         builder.setEnvironmentVariables("FOO=bar\nHELLO=world");
         builder.setSetupScript("export PATH=$HOME/.local/bin:$PATH\nnpm install");
         builder.setFailOnAgentError(false);
+        builder.setDisableInteractive(true);
         project.getBuildersList().add(builder);
         project.save();
 
@@ -59,6 +60,7 @@ class AiAgentBuilderConfigRoundTripTest {
         assertEquals("FOO=bar\nHELLO=world", reloaded.getEnvironmentVariables());
         assertEquals("export PATH=$HOME/.local/bin:$PATH\nnpm install", reloaded.getSetupScript());
         assertFalse(reloaded.isFailOnAgentError());
+        assertTrue(reloaded.isDisableInteractive());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuilderConfigRoundTripTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuilderConfigRoundTripTest.java
@@ -6,100 +6,108 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.model.FreeStyleProject;
+
 import io.jenkins.plugins.aiagentjob.geminicli.GeminiCliAgentHandler;
+
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
-import org.junit.jupiter.api.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class AiAgentBuilderConfigRoundTripTest {
 
-  @Test
-  void preservesConfiguredFields(JenkinsRule jenkins) throws Exception {
-    FreeStyleProject project = jenkins.createFreeStyleProject("ai-config-roundtrip");
-    AiAgentBuilder builder = new AiAgentBuilder();
-    builder.setAgent(new GeminiCliAgentHandler());
-    builder.setPrompt("Summarize this repository.");
-    builder.setModel("gemini-2.5-pro");
-    builder.setWorkingDirectory("src");
-    builder.setYoloMode(false);
-    builder.setRequireApprovals(true);
-    builder.setApprovalTimeoutSeconds(42);
-    builder.setCommandOverride("echo '{\"type\":\"assistant\",\"message\":\"hi\"}'");
-    builder.setExtraArgs("--foo bar");
-    builder.setEnvironmentVariables("FOO=bar\nHELLO=world");
-    builder.setSetupScript("export PATH=$HOME/.local/bin:$PATH\nnpm install");
-    builder.setFailOnAgentError(false);
-    builder.setDisableInteractive(true);
-    project.getBuildersList().add(builder);
-    project.save();
+    @Test
+    void preservesConfiguredFields(JenkinsRule jenkins) throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject("ai-config-roundtrip");
+        AiAgentBuilder builder = new AiAgentBuilder();
+        builder.setAgent(new GeminiCliAgentHandler());
+        builder.setPrompt("Summarize this repository.");
+        builder.setModel("gemini-2.5-pro");
+        builder.setWorkingDirectory("src");
+        builder.setYoloMode(false);
+        builder.setRequireApprovals(true);
+        builder.setApprovalTimeoutSeconds(42);
+        builder.setCommandOverride("echo '{\"type\":\"assistant\",\"message\":\"hi\"}'");
+        builder.setExtraArgs("--foo bar");
+        builder.setEnvironmentVariables("FOO=bar\nHELLO=world");
+        builder.setSetupScript("export PATH=$HOME/.local/bin:$PATH\nnpm install");
+        builder.setFailOnAgentError(false);
+        builder.setDisableInteractive(true);
+        project.getBuildersList().add(builder);
+        project.save();
 
-    project = jenkins.configRoundtrip(project);
+        project = jenkins.configRoundtrip(project);
 
-    AiAgentBuilder reloaded = (AiAgentBuilder) project.getBuildersList().get(0);
-    assertEquals("GEMINI_CLI", reloaded.getAgent().getId());
-    assertEquals("Summarize this repository.", reloaded.getPrompt());
-    assertEquals("gemini-2.5-pro", reloaded.getModel());
-    assertEquals("src", reloaded.getWorkingDirectory());
-    assertFalse(reloaded.isYoloMode());
-    assertTrue(reloaded.isRequireApprovals());
-    assertEquals(42, reloaded.getApprovalTimeoutSeconds());
-    assertEquals(
-        "echo '{\"type\":\"assistant\",\"message\":\"hi\"}'", reloaded.getCommandOverride());
-    assertEquals("--foo bar", reloaded.getExtraArgs());
-    assertEquals("FOO=bar\nHELLO=world", reloaded.getEnvironmentVariables());
-    assertEquals("export PATH=$HOME/.local/bin:$PATH\nnpm install", reloaded.getSetupScript());
-    assertFalse(reloaded.isFailOnAgentError());
-    assertTrue(reloaded.isDisableInteractive());
-  }
-
-  @Test
-  void commandOverride_normalizesWrappedLineBreaks() {
-    AiAgentBuilder builder = new AiAgentBuilder();
-    builder.setCommandOverride("/opt/opencode\n  --model gpt-5\n  --json");
-    assertEquals("/opt/opencode --model gpt-5 --json", builder.getCommandOverride());
-  }
-
-  @Test
-  void configJelly_usesDescriptorSelectorWithoutInlineScripts() throws Exception {
-    String jelly = readResource("/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly");
-    assertTrue(
-        jelly.contains(
-            "<f:dropdownDescriptorSelector title=\"Agent Type\" field=\"agent\""
-                + " descriptors=\"${descriptor.agentDescriptors}\" />"),
-        "config.jelly should use descriptor selector");
-    assertTrue(jelly.contains("<f:textbox />"), "command override should use textbox");
-    assertFalse(
-        jelly.contains("<f:expandableTextbox"),
-        "command override should not use expandableTextbox");
-    assertFalse(jelly.contains("<style"), "config.jelly should not contain inline style tags");
-    assertFalse(jelly.contains("<script"), "config.jelly should not contain inline script tags");
-    assertFalse(
-        jelly.contains(" style=") || jelly.contains("style=\"") || jelly.contains("style='"),
-        "config.jelly should not contain inline style attributes");
-  }
-
-  @Test
-  void codexHandlerConfigJelly_exists() {
-    assertNotNull(
-        getClass()
-            .getResource("/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler/config.jelly"),
-        "codex handler config resource should exist");
-  }
-
-  private String readResource(String path) throws IOException {
-    try (InputStream in = getClass().getResourceAsStream(path)) {
-      assertNotNull(in, "Resource should exist: " + path);
-      try (BufferedReader reader =
-          new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
-        return reader.lines().collect(Collectors.joining("\n"));
-      }
+        AiAgentBuilder reloaded = (AiAgentBuilder) project.getBuildersList().get(0);
+        assertEquals("GEMINI_CLI", reloaded.getAgent().getId());
+        assertEquals("Summarize this repository.", reloaded.getPrompt());
+        assertEquals("gemini-2.5-pro", reloaded.getModel());
+        assertEquals("src", reloaded.getWorkingDirectory());
+        assertFalse(reloaded.isYoloMode());
+        assertTrue(reloaded.isRequireApprovals());
+        assertEquals(42, reloaded.getApprovalTimeoutSeconds());
+        assertEquals(
+                "echo '{\"type\":\"assistant\",\"message\":\"hi\"}'",
+                reloaded.getCommandOverride());
+        assertEquals("--foo bar", reloaded.getExtraArgs());
+        assertEquals("FOO=bar\nHELLO=world", reloaded.getEnvironmentVariables());
+        assertEquals("export PATH=$HOME/.local/bin:$PATH\nnpm install", reloaded.getSetupScript());
+        assertFalse(reloaded.isFailOnAgentError());
+        assertTrue(reloaded.isDisableInteractive());
     }
-  }
+
+    @Test
+    void commandOverride_normalizesWrappedLineBreaks() {
+        AiAgentBuilder builder = new AiAgentBuilder();
+        builder.setCommandOverride("/opt/opencode\n  --model gpt-5\n  --json");
+        assertEquals("/opt/opencode --model gpt-5 --json", builder.getCommandOverride());
+    }
+
+    @Test
+    void configJelly_usesDescriptorSelectorWithoutInlineScripts() throws Exception {
+        String jelly = readResource("/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly");
+        assertTrue(
+                jelly.contains(
+                        "<f:dropdownDescriptorSelector title=\"Agent Type\" field=\"agent\""
+                                + " descriptors=\"${descriptor.agentDescriptors}\" />"),
+                "config.jelly should use descriptor selector");
+        assertTrue(jelly.contains("<f:textbox />"), "command override should use textbox");
+        assertFalse(
+                jelly.contains("<f:expandableTextbox"),
+                "command override should not use expandableTextbox");
+        assertFalse(jelly.contains("<style"), "config.jelly should not contain inline style tags");
+        assertFalse(
+                jelly.contains("<script"), "config.jelly should not contain inline script tags");
+        assertFalse(
+                jelly.contains(" style=")
+                        || jelly.contains("style=\"")
+                        || jelly.contains("style='"),
+                "config.jelly should not contain inline style attributes");
+    }
+
+    @Test
+    void codexHandlerConfigJelly_exists() {
+        assertNotNull(
+                getClass()
+                        .getResource(
+                                "/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler/config.jelly"),
+                "codex handler config resource should exist");
+    }
+
+    private String readResource(String path) throws IOException {
+        try (InputStream in = getClass().getResourceAsStream(path)) {
+            assertNotNull(in, "Resource should exist: " + path);
+            try (BufferedReader reader =
+                    new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+                return reader.lines().collect(Collectors.joining("\n"));
+            }
+        }
+    }
 }

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuilderConfigRoundTripTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuilderConfigRoundTripTest.java
@@ -6,107 +6,100 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.model.FreeStyleProject;
-
 import io.jenkins.plugins.aiagentjob.geminicli.GeminiCliAgentHandler;
-
-import org.junit.jupiter.api.Test;
-import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 @WithJenkins
 class AiAgentBuilderConfigRoundTripTest {
 
-    @Test
-    void preservesConfiguredFields(JenkinsRule jenkins) throws Exception {
-        FreeStyleProject project = jenkins.createFreeStyleProject("ai-config-roundtrip");
-        AiAgentBuilder builder = new AiAgentBuilder();
-        builder.setAgent(new GeminiCliAgentHandler());
-        builder.setPrompt("Summarize this repository.");
-        builder.setModel("gemini-2.5-pro");
-        builder.setWorkingDirectory("src");
-        builder.setYoloMode(false);
-        builder.setRequireApprovals(true);
-        builder.setApprovalTimeoutSeconds(42);
-        builder.setCommandOverride("echo '{\"type\":\"assistant\",\"message\":\"hi\"}'");
-        builder.setExtraArgs("--foo bar");
-        builder.setEnvironmentVariables("FOO=bar\nHELLO=world");
-        builder.setSetupScript("export PATH=$HOME/.local/bin:$PATH\nnpm install");
-        builder.setFailOnAgentError(false);
-        builder.setDisableInteractive(true);
-        project.getBuildersList().add(builder);
-        project.save();
+  @Test
+  void preservesConfiguredFields(JenkinsRule jenkins) throws Exception {
+    FreeStyleProject project = jenkins.createFreeStyleProject("ai-config-roundtrip");
+    AiAgentBuilder builder = new AiAgentBuilder();
+    builder.setAgent(new GeminiCliAgentHandler());
+    builder.setPrompt("Summarize this repository.");
+    builder.setModel("gemini-2.5-pro");
+    builder.setWorkingDirectory("src");
+    builder.setYoloMode(false);
+    builder.setRequireApprovals(true);
+    builder.setApprovalTimeoutSeconds(42);
+    builder.setCommandOverride("echo '{\"type\":\"assistant\",\"message\":\"hi\"}'");
+    builder.setExtraArgs("--foo bar");
+    builder.setEnvironmentVariables("FOO=bar\nHELLO=world");
+    builder.setSetupScript("export PATH=$HOME/.local/bin:$PATH\nnpm install");
+    builder.setFailOnAgentError(false);
+    builder.setDisableInteractive(true);
+    project.getBuildersList().add(builder);
+    project.save();
 
-        project = jenkins.configRoundtrip(project);
+    project = jenkins.configRoundtrip(project);
 
-        AiAgentBuilder reloaded = (AiAgentBuilder) project.getBuildersList().get(0);
-        assertEquals("GEMINI_CLI", reloaded.getAgent().getId());
-        assertEquals("Summarize this repository.", reloaded.getPrompt());
-        assertEquals("gemini-2.5-pro", reloaded.getModel());
-        assertEquals("src", reloaded.getWorkingDirectory());
-        assertFalse(reloaded.isYoloMode());
-        assertTrue(reloaded.isRequireApprovals());
-        assertEquals(42, reloaded.getApprovalTimeoutSeconds());
-        assertEquals(
-                "echo '{\"type\":\"assistant\",\"message\":\"hi\"}'",
-                reloaded.getCommandOverride());
-        assertEquals("--foo bar", reloaded.getExtraArgs());
-        assertEquals("FOO=bar\nHELLO=world", reloaded.getEnvironmentVariables());
-        assertEquals("export PATH=$HOME/.local/bin:$PATH\nnpm install", reloaded.getSetupScript());
-        assertFalse(reloaded.isFailOnAgentError());
-        assertTrue(reloaded.isDisableInteractive());
+    AiAgentBuilder reloaded = (AiAgentBuilder) project.getBuildersList().get(0);
+    assertEquals("GEMINI_CLI", reloaded.getAgent().getId());
+    assertEquals("Summarize this repository.", reloaded.getPrompt());
+    assertEquals("gemini-2.5-pro", reloaded.getModel());
+    assertEquals("src", reloaded.getWorkingDirectory());
+    assertFalse(reloaded.isYoloMode());
+    assertTrue(reloaded.isRequireApprovals());
+    assertEquals(42, reloaded.getApprovalTimeoutSeconds());
+    assertEquals(
+        "echo '{\"type\":\"assistant\",\"message\":\"hi\"}'", reloaded.getCommandOverride());
+    assertEquals("--foo bar", reloaded.getExtraArgs());
+    assertEquals("FOO=bar\nHELLO=world", reloaded.getEnvironmentVariables());
+    assertEquals("export PATH=$HOME/.local/bin:$PATH\nnpm install", reloaded.getSetupScript());
+    assertFalse(reloaded.isFailOnAgentError());
+    assertTrue(reloaded.isDisableInteractive());
+  }
+
+  @Test
+  void commandOverride_normalizesWrappedLineBreaks() {
+    AiAgentBuilder builder = new AiAgentBuilder();
+    builder.setCommandOverride("/opt/opencode\n  --model gpt-5\n  --json");
+    assertEquals("/opt/opencode --model gpt-5 --json", builder.getCommandOverride());
+  }
+
+  @Test
+  void configJelly_usesDescriptorSelectorWithoutInlineScripts() throws Exception {
+    String jelly = readResource("/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly");
+    assertTrue(
+        jelly.contains(
+            "<f:dropdownDescriptorSelector title=\"Agent Type\" field=\"agent\""
+                + " descriptors=\"${descriptor.agentDescriptors}\" />"),
+        "config.jelly should use descriptor selector");
+    assertTrue(jelly.contains("<f:textbox />"), "command override should use textbox");
+    assertFalse(
+        jelly.contains("<f:expandableTextbox"),
+        "command override should not use expandableTextbox");
+    assertFalse(jelly.contains("<style"), "config.jelly should not contain inline style tags");
+    assertFalse(jelly.contains("<script"), "config.jelly should not contain inline script tags");
+    assertFalse(
+        jelly.contains(" style=") || jelly.contains("style=\"") || jelly.contains("style='"),
+        "config.jelly should not contain inline style attributes");
+  }
+
+  @Test
+  void codexHandlerConfigJelly_exists() {
+    assertNotNull(
+        getClass()
+            .getResource("/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler/config.jelly"),
+        "codex handler config resource should exist");
+  }
+
+  private String readResource(String path) throws IOException {
+    try (InputStream in = getClass().getResourceAsStream(path)) {
+      assertNotNull(in, "Resource should exist: " + path);
+      try (BufferedReader reader =
+          new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
+        return reader.lines().collect(Collectors.joining("\n"));
+      }
     }
-
-    @Test
-    void commandOverride_normalizesWrappedLineBreaks() {
-        AiAgentBuilder builder = new AiAgentBuilder();
-        builder.setCommandOverride("/opt/opencode\n  --model gpt-5\n  --json");
-        assertEquals("/opt/opencode --model gpt-5 --json", builder.getCommandOverride());
-    }
-
-    @Test
-    void configJelly_usesDescriptorSelectorWithoutInlineScripts() throws Exception {
-        String jelly = readResource("/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly");
-        assertTrue(
-                jelly.contains(
-                        "<f:dropdownDescriptorSelector title=\"Agent Type\" field=\"agent\" descriptors=\"${descriptor.agentDescriptors}\" />"),
-                "config.jelly should use descriptor selector");
-        assertTrue(jelly.contains("<f:textbox />"), "command override should use textbox");
-        assertFalse(
-                jelly.contains("<f:expandableTextbox"),
-                "command override should not use expandableTextbox");
-        assertFalse(jelly.contains("<style"), "config.jelly should not contain inline style tags");
-        assertFalse(
-                jelly.contains("<script"), "config.jelly should not contain inline script tags");
-        assertFalse(
-                jelly.contains(" style=")
-                        || jelly.contains("style=\"")
-                        || jelly.contains("style='"),
-                "config.jelly should not contain inline style attributes");
-    }
-
-    @Test
-    void codexHandlerConfigJelly_exists() {
-        assertNotNull(
-                getClass()
-                        .getResource(
-                                "/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler/config.jelly"),
-                "codex handler config resource should exist");
-    }
-
-    private String readResource(String path) throws IOException {
-        try (InputStream in = getClass().getResourceAsStream(path)) {
-            assertNotNull(in, "Resource should exist: " + path);
-            try (BufferedReader reader =
-                    new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8))) {
-                return reader.lines().collect(Collectors.joining("\n"));
-            }
-        }
-    }
+  }
 }


### PR DESCRIPTION
Resolves #8

This adds a `disableInteractive` option to the configuration that automatically provides an empty stdin (e.g. `< /dev/null`) to prevent agents from blocking on interactive input. This makes it possible to avoid creating a custom `commandOverride` just to add it.