### PR TITLE
[codex] Update CLI integration coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Plugin ID (artifactId): `ai-agent`
 - **Markdown rendering** — assistant and result messages are rendered as formatted HTML.
 - **Approval gates** — optionally pause builds for human review before tool execution.
 - **Usage statistics** — token counts, cost, and duration extracted from agent logs and displayed per build.
-- **Codex per-job config** — optionally provide a job-scoped `~/.codex/config.toml` to override settings/MCP for Codex runs.
+- **Codex controls** — job-scoped `~/.codex/config.toml`, global Codex args, and `codex exec` args for Codex runs.
 - **Standard Jenkins integrations** — SCM checkout, build triggers, credentials injection, post-build shell steps, and publishers.
 
 ## Supported Agents
@@ -59,10 +59,12 @@ Build page showing a Cursor Agent conversation with tool calls, markdown-rendere
    - **Agent Type** — select the coding agent to run.
    - **Prompt** — the task to send to the agent.
    - **Model** — optional model override (e.g., `claude-sonnet-4`).
+   - **Reasoning effort** — optional effort override for supported agents (e.g., `high`, `xhigh`).
    - **YOLO mode** — skip confirmation prompts in the agent.
    - **Approvals** — require human approval for tool calls.
    - **Setup script** — shell commands to run before the agent (install tools, source dotfiles, export secrets).
    - **Custom Codex config.toml** — optional, shown only for Codex runs to override settings/MCP per job.
+   - **Additional Codex args** — optional, shown only for Codex runs to pass global flags like `--search` or exec flags like `--ephemeral`.
    - **Environment variables** — inject additional env vars (`KEY=VALUE`, one per line).
    - **Command override** — replace the default command template entirely.
    - **Extra CLI args** — append flags to the generated command.
@@ -99,9 +101,12 @@ Codex with job-scoped `config.toml`:
 aiAgent(
   agent: codex(
     customConfigEnabled: true,
-    customConfigToml: '[model]\\nname = \"gpt-5\"'
+    customConfigToml: 'model = \"gpt-5.5\"',
+    additionalGlobalArgs: '--search',
+    additionalExecArgs: '--ephemeral --color never'
   ),
   prompt: 'Summarize this project',
+  reasoningEffort: 'xhigh',
   approvalTimeoutSeconds: 60
 )
 ```
@@ -123,6 +128,7 @@ The plugin injects these variables into every build:
 |----------|-------------|
 | `AI_AGENT_PROMPT` | The configured prompt text |
 | `AI_AGENT_MODEL` | The configured model name |
+| `AI_AGENT_REASONING_EFFORT` | The configured reasoning effort |
 
 ### Setup Script
 
@@ -157,6 +163,28 @@ For **Codex CLI** jobs, you can enable a custom config and paste TOML content eq
 `~/.codex/config.toml`. At runtime, the plugin creates a temporary home directory for the build,
 writes `.codex/config.toml` there, and launches Codex with that run-scoped home so settings/MCP
 overrides apply only to that job run.
+
+By default, Codex runs as:
+
+```bash
+codex --sandbox workspace-write --ask-for-approval never exec --json --skip-git-repo-check '<prompt>'
+```
+
+Use **Additional Codex global args** for flags that must appear before `exec`, such as
+`--search`, `--profile ci`, `-c key=value`, `--enable feature`, or `--image path.png`.
+Use **Additional Codex exec args** for flags after `exec`, such as `--ephemeral`,
+`--ignore-user-config`, `--ignore-rules`, `--add-dir path`, `--output-schema schema.json`,
+or `--color never`. Keep secrets in Jenkins credentials or config, not in CLI args.
+
+### Reasoning Effort
+
+The **Reasoning effort** field is passed only to agents with verified CLI support:
+
+- Codex CLI: `-c model_reasoning_effort="<value>"`
+- Claude Code: `--effort <value>`
+- OpenCode: `--variant <value>`
+
+Gemini CLI and Cursor Agent currently ignore the field in the built-in command template.
 
 ### Credential Injection
 

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AgentUsageStats.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AgentUsageStats.java
@@ -373,6 +373,13 @@ public final class AgentUsageStats implements Serializable {
                                 usage.optLong(
                                         "cacheWriteTokens",
                                         usage.optLong("cacheCreationInputTokens", 0))));
+        reasoningTokens =
+                Math.max(
+                        reasoningTokens,
+                        usage.optLong(
+                                "reasoning_output_tokens",
+                                usage.optLong(
+                                        "reasoningTokens", usage.optLong("reasoning_output", 0))));
 
         // Codex uses cached_input_tokens
         if (usage.has("cached_input_tokens") && !usage.has("cache_read_input_tokens")) {

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentBuilder.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentBuilder.java
@@ -42,6 +42,7 @@ import java.util.List;
 public class AiAgentBuilder extends Builder implements SimpleBuildStep, AiAgentConfiguration {
     private AiAgentTypeHandler agent = new ClaudeCodeAgentHandler();
     private String model = "";
+    private String reasoningEffort = "";
     private String prompt = "";
     private String workingDirectory = "";
     private boolean yoloMode;
@@ -105,6 +106,16 @@ public class AiAgentBuilder extends Builder implements SimpleBuildStep, AiAgentC
     @DataBoundSetter
     public void setModel(String model) {
         this.model = Util.fixNull(model);
+    }
+
+    @Override
+    public String getReasoningEffort() {
+        return reasoningEffort;
+    }
+
+    @DataBoundSetter
+    public void setReasoningEffort(String reasoningEffort) {
+        this.reasoningEffort = Util.fixNull(reasoningEffort);
     }
 
     @Override
@@ -247,6 +258,7 @@ public class AiAgentBuilder extends Builder implements SimpleBuildStep, AiAgentC
             agent = new ClaudeCodeAgentHandler();
         }
         model = Util.fixNull(model);
+        reasoningEffort = Util.fixNull(reasoningEffort);
         prompt = Util.fixNull(prompt);
         workingDirectory = Util.fixNull(workingDirectory);
         commandOverride = normalizeCommandOverride(commandOverride);

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentConfiguration.java
@@ -6,6 +6,8 @@ public interface AiAgentConfiguration {
 
     String getModel();
 
+    String getReasoningEffort();
+
     String getPrompt();
 
     String getWorkingDirectory();

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -92,6 +92,7 @@ final class AiAgentExecutor {
 
         procEnv.put("AI_AGENT_PROMPT", prompt);
         procEnv.put("AI_AGENT_MODEL", model);
+        procEnv.put("AI_AGENT_REASONING_EFFORT", Util.fixNull(config.getReasoningEffort()));
 
         String setupScript = Util.fixNull(config.getSetupScript()).trim();
         if (!setupScript.isEmpty() && !launcher.isUnix()) {

--- a/src/main/java/io/jenkins/plugins/aiagentjob/claudecode/ClaudeCodeAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/claudecode/ClaudeCodeAgentHandler.java
@@ -49,6 +49,11 @@ public final class ClaudeCodeAgentHandler extends AiAgentTypeHandler {
             command.add("--model");
             command.add(model);
         }
+        String reasoningEffort = Util.fixEmptyAndTrim(config.getReasoningEffort());
+        if (reasoningEffort != null) {
+            command.add("--effort");
+            command.add(reasoningEffort);
+        }
         return command;
     }
 

--- a/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler.java
@@ -24,6 +24,8 @@ import java.util.List;
 public final class CodexAgentHandler extends AiAgentTypeHandler {
     private boolean customConfigEnabled;
     private String customConfigToml = "";
+    private String additionalGlobalArgs = "";
+    private String additionalExecArgs = "";
 
     @DataBoundConstructor
     public CodexAgentHandler() {}
@@ -42,23 +44,45 @@ public final class CodexAgentHandler extends AiAgentTypeHandler {
     public List<String> buildDefaultCommand(AiAgentConfiguration config, String prompt) {
         List<String> command = new ArrayList<>();
         command.add("codex");
-        command.add("exec");
-        command.add("--json");
-        command.add("--skip-git-repo-check");
+        addTokenizedArgs(command, additionalGlobalArgs);
         if (config.isYoloMode()) {
             command.add("--dangerously-bypass-approvals-and-sandbox");
         } else {
             command.add("--sandbox");
             command.add("workspace-write");
-            command.add("--full-auto");
+            command.add("--ask-for-approval");
+            command.add("never");
         }
         String model = Util.fixEmptyAndTrim(config.getModel());
         if (model != null) {
             command.add("--model");
             command.add(model);
         }
+        String reasoningEffort = Util.fixEmptyAndTrim(config.getReasoningEffort());
+        if (reasoningEffort != null) {
+            command.add("-c");
+            command.add("model_reasoning_effort=" + tomlString(reasoningEffort));
+        }
+        command.add("exec");
+        command.add("--json");
+        command.add("--skip-git-repo-check");
+        addTokenizedArgs(command, additionalExecArgs);
         command.add(prompt);
         return command;
+    }
+
+    private static void addTokenizedArgs(List<String> command, String rawArgs) {
+        String args = Util.fixEmptyAndTrim(rawArgs);
+        if (args == null) {
+            return;
+        }
+        for (String arg : Util.tokenize(args)) {
+            command.add(arg);
+        }
+    }
+
+    private static String tomlString(String value) {
+        return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
     }
 
     @Override
@@ -99,6 +123,31 @@ public final class CodexAgentHandler extends AiAgentTypeHandler {
     @DataBoundSetter
     public void setCustomConfigToml(String customConfigToml) {
         this.customConfigToml = Util.fixNull(customConfigToml);
+    }
+
+    public String getAdditionalGlobalArgs() {
+        return additionalGlobalArgs;
+    }
+
+    @DataBoundSetter
+    public void setAdditionalGlobalArgs(String additionalGlobalArgs) {
+        this.additionalGlobalArgs = Util.fixNull(additionalGlobalArgs);
+    }
+
+    public String getAdditionalExecArgs() {
+        return additionalExecArgs;
+    }
+
+    @DataBoundSetter
+    public void setAdditionalExecArgs(String additionalExecArgs) {
+        this.additionalExecArgs = Util.fixNull(additionalExecArgs);
+    }
+
+    private Object readResolve() {
+        customConfigToml = Util.fixNull(customConfigToml);
+        additionalGlobalArgs = Util.fixNull(additionalGlobalArgs);
+        additionalExecArgs = Util.fixNull(additionalExecArgs);
+        return this;
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeAgentHandler.java
@@ -44,6 +44,11 @@ public final class OpenCodeAgentHandler extends AiAgentTypeHandler {
             command.add("--model");
             command.add(model);
         }
+        String reasoningEffort = Util.fixEmptyAndTrim(config.getReasoningEffort());
+        if (reasoningEffort != null) {
+            command.add("--variant");
+            command.add(reasoningEffort);
+        }
         command.add(prompt);
         return command;
     }

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly
@@ -10,6 +10,10 @@
     <f:textbox />
   </f:entry>
 
+  <f:entry title="Reasoning effort (optional)" field="reasoningEffort">
+    <f:textbox />
+  </f:entry>
+
   <f:entry title="Working directory" field="workingDirectory" description="Relative to the job workspace. Leave empty to run in workspace root.">
     <f:textbox />
   </f:entry>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-reasoningEffort.html
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-reasoningEffort.html
@@ -1,0 +1,7 @@
+<div>
+  Optional reasoning effort for agents that support it. Codex maps this to
+  <code>model_reasoning_effort</code>, Claude Code maps it to <code>--effort</code>,
+  and OpenCode maps it to <code>--variant</code>. Common values include
+  <code>low</code>, <code>medium</code>, <code>high</code>, <code>xhigh</code>, and
+  <code>max</code>. Unsupported agents ignore this field.
+</div>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler/config.jelly
@@ -5,4 +5,13 @@
       <f:textarea />
     </f:entry>
   </f:optionalBlock>
+
+  <f:advanced>
+    <f:entry title="Additional Codex global args" field="additionalGlobalArgs">
+      <f:textbox />
+    </f:entry>
+    <f:entry title="Additional Codex exec args" field="additionalExecArgs">
+      <f:textbox />
+    </f:entry>
+  </f:advanced>
 </j:jelly>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler/help-additionalExecArgs.html
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler/help-additionalExecArgs.html
@@ -1,0 +1,7 @@
+<div>
+  Extra arguments inserted after <code>codex exec --json --skip-git-repo-check</code> and before
+  the prompt. Use this for exec flags such as <code>--ephemeral</code>,
+  <code>--ignore-user-config</code>, <code>--ignore-rules</code>, <code>--add-dir path</code>,
+  <code>--output-schema schema.json</code>, or <code>--color never</code>.
+  Arguments are split on whitespace.
+</div>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler/help-additionalGlobalArgs.html
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler/help-additionalGlobalArgs.html
@@ -1,0 +1,6 @@
+<div>
+  Extra arguments inserted after <code>codex</code> and before <code>exec</code>.
+  Use this for global Codex flags such as <code>--search</code>, <code>--profile ci</code>,
+  <code>-c key=value</code>, <code>--enable feature</code>, or <code>--image path.png</code>.
+  Arguments are split on whitespace. Keep secrets in Jenkins credentials or config, not here.
+</div>

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AgentUsageStatsTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AgentUsageStatsTest.java
@@ -96,9 +96,10 @@ class AgentUsageStatsTest {
         AgentUsageStats stats = parseStats("stats-codex.jsonl", CodexStatsExtractor.INSTANCE);
 
         assertTrue(stats.hasData());
-        assertEquals(25602, stats.getInputTokens());
-        assertEquals(116, stats.getOutputTokens());
-        assertEquals(3456, stats.getCacheReadTokens());
+        assertEquals(42581, stats.getInputTokens());
+        assertEquals(108, stats.getOutputTokens());
+        assertEquals(30976, stats.getCacheReadTokens());
+        assertEquals(49, stats.getReasoningTokens());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
@@ -319,7 +319,7 @@ class AiAgentBuildExecutionTest {
                         b -> {
                             CodexAgentHandler codex = new CodexAgentHandler();
                             codex.setCustomConfigEnabled(true);
-                            codex.setCustomConfigToml("[model]\nname = \"gpt-5\"");
+                            codex.setCustomConfigToml("model = \"gpt-5.5\"");
                             b.setAgent(codex);
                             b.setPrompt("hello");
                             b.setCommandOverride(

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuilderConfigRoundTripTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuilderConfigRoundTripTest.java
@@ -30,6 +30,7 @@ class AiAgentBuilderConfigRoundTripTest {
         builder.setAgent(new GeminiCliAgentHandler());
         builder.setPrompt("Summarize this repository.");
         builder.setModel("gemini-2.5-pro");
+        builder.setReasoningEffort("high");
         builder.setWorkingDirectory("src");
         builder.setYoloMode(false);
         builder.setRequireApprovals(true);
@@ -49,6 +50,7 @@ class AiAgentBuilderConfigRoundTripTest {
         assertEquals("GEMINI_CLI", reloaded.getAgent().getId());
         assertEquals("Summarize this repository.", reloaded.getPrompt());
         assertEquals("gemini-2.5-pro", reloaded.getModel());
+        assertEquals("high", reloaded.getReasoningEffort());
         assertEquals("src", reloaded.getWorkingDirectory());
         assertFalse(reloaded.isYoloMode());
         assertTrue(reloaded.isRequireApprovals());

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
@@ -96,6 +96,18 @@ class AiAgentCommandFactoryTest {
         assertEquals("claude-opus-4", cmd.get(modelIdx + 1));
     }
 
+    @Test
+    void claudeCode_withReasoningEffort() {
+        AiAgentBuilder project = createProject(new ClaudeCodeAgentHandler());
+        project.setReasoningEffort("xhigh");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        int effortIdx = cmd.indexOf("--effort");
+        assertTrue(effortIdx >= 0, "Should have --effort");
+        assertEquals("xhigh", cmd.get(effortIdx + 1));
+    }
+
     // ======================== Codex Command Tests ========================
 
     @Test
@@ -105,7 +117,7 @@ class AiAgentCommandFactoryTest {
         List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "fix the bug");
 
         assertEquals("codex", cmd.get(0));
-        assertEquals("exec", cmd.get(1));
+        assertTrue(cmd.indexOf("exec") > 0, "Should run codex exec");
         assertTrue(cmd.contains("--json"), "Should have --json for JSONL output");
         assertTrue(
                 cmd.contains("--skip-git-repo-check"),
@@ -124,7 +136,9 @@ class AiAgentCommandFactoryTest {
                 cmd.contains("--dangerously-bypass-approvals-and-sandbox"),
                 "Should have --dangerously-bypass-approvals-and-sandbox");
         assertFalse(cmd.contains("--sandbox"), "Should NOT have --sandbox");
-        assertFalse(cmd.contains("--full-auto"), "Should NOT have --full-auto in yolo mode");
+        assertFalse(
+                cmd.contains("--ask-for-approval"),
+                "Should NOT have --ask-for-approval in yolo mode");
     }
 
     @Test
@@ -136,10 +150,12 @@ class AiAgentCommandFactoryTest {
 
         assertTrue(cmd.contains("--sandbox"), "Should have --sandbox");
         assertTrue(cmd.contains("workspace-write"), "Should have workspace-write");
-        assertTrue(cmd.contains("--full-auto"), "Should have --full-auto for headless execution");
-        assertFalse(
-                cmd.contains("--ask-for-approval"),
-                "Should NOT have --ask-for-approval (not valid for codex exec)");
+        int approvalIdx = cmd.indexOf("--ask-for-approval");
+        assertTrue(approvalIdx > 0, "Should have --ask-for-approval for headless execution");
+        assertEquals("never", cmd.get(approvalIdx + 1));
+        assertTrue(cmd.indexOf("--sandbox") < cmd.indexOf("exec"), "--sandbox is a global flag");
+        assertTrue(approvalIdx < cmd.indexOf("exec"), "--ask-for-approval is a global flag");
+        assertFalse(cmd.contains("--full-auto"), "Should not use removed --full-auto flag");
     }
 
     @Test
@@ -155,12 +171,46 @@ class AiAgentCommandFactoryTest {
     }
 
     @Test
+    void codex_withReasoningEffort() {
+        AiAgentBuilder project = createProject(new CodexAgentHandler());
+        project.setReasoningEffort("high");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        int configIdx = cmd.indexOf("-c");
+        assertTrue(configIdx > 0, "Should have config override");
+        assertEquals("model_reasoning_effort=\"high\"", cmd.get(configIdx + 1));
+        assertTrue(configIdx < cmd.indexOf("exec"), "Codex reasoning effort is a global config");
+    }
+
+    @Test
     void codex_promptIsLastArgument() {
         AiAgentBuilder project = createProject(new CodexAgentHandler());
 
         List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "refactor this");
 
         assertEquals("refactor this", cmd.get(cmd.size() - 1), "Prompt should be last argument");
+    }
+
+    @Test
+    void codex_additionalArgsArePlacedInCodexScopes() {
+        CodexAgentHandler codex = new CodexAgentHandler();
+        codex.setAdditionalGlobalArgs("--search --profile ci");
+        codex.setAdditionalExecArgs("--ephemeral --ignore-user-config --color never");
+        AiAgentBuilder project = createProject(codex);
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        int execIdx = cmd.indexOf("exec");
+        int promptIdx = cmd.indexOf("test");
+        assertTrue(cmd.indexOf("--search") > 0 && cmd.indexOf("--search") < execIdx);
+        assertTrue(cmd.indexOf("--profile") > 0 && cmd.indexOf("--profile") < execIdx);
+        assertEquals("ci", cmd.get(cmd.indexOf("--profile") + 1));
+        assertTrue(cmd.indexOf("--ephemeral") > execIdx && cmd.indexOf("--ephemeral") < promptIdx);
+        assertTrue(
+                cmd.indexOf("--ignore-user-config") > execIdx
+                        && cmd.indexOf("--ignore-user-config") < promptIdx);
+        assertEquals("never", cmd.get(cmd.indexOf("--color") + 1));
     }
 
     // ======================== Cursor Agent Command Tests ========================
@@ -228,6 +278,18 @@ class AiAgentCommandFactoryTest {
         int modelIdx = cmd.indexOf("--model");
         assertTrue(modelIdx >= 0, "Should have --model");
         assertEquals("anthropic/claude-sonnet-4", cmd.get(modelIdx + 1));
+    }
+
+    @Test
+    void openCode_withReasoningEffort() {
+        AiAgentBuilder project = createProject(new OpenCodeAgentHandler());
+        project.setReasoningEffort("max");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        int variantIdx = cmd.indexOf("--variant");
+        assertTrue(variantIdx >= 0, "Should have --variant");
+        assertEquals("max", cmd.get(variantIdx + 1));
     }
 
     // ======================== Gemini CLI Command Tests ========================

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentLogParserTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentLogParserTest.java
@@ -138,7 +138,7 @@ class AiAgentLogParserTest {
                 cats.contains("tool_result"),
                 "Should have tool_result (command_execution completed)");
         assertTrue(cats.contains("assistant"), "Should have assistant (agent_message)");
-        assertEquals(6, events.size(), "Current Codex fixture should keep only 6 visible events");
+        assertEquals(11, events.size(), "Current Codex fixture should keep 11 visible events");
     }
 
     @Test
@@ -150,9 +150,11 @@ class AiAgentLogParserTest {
                         .filter(e -> "tool_call".equals(e.getCategory()))
                         .collect(Collectors.toList());
 
-        assertEquals(2, toolCalls.size(), "Should have 2 visible command starts");
-        assertTrue(toolCalls.stream().anyMatch(e -> e.getToolInput().contains("git remote -v")));
+        assertEquals(4, toolCalls.size(), "Should have 3 command starts and 1 MCP tool call");
         assertTrue(toolCalls.stream().anyMatch(e -> e.getToolInput().contains("rg --files")));
+        assertTrue(toolCalls.stream().anyMatch(e -> e.getToolInput().contains("sed -n")));
+        assertTrue(toolCalls.stream().anyMatch(e -> e.getToolInput().contains("mvn -q")));
+        assertTrue(toolCalls.stream().anyMatch(e -> e.getToolInput().contains("server")));
     }
 
     @Test
@@ -161,9 +163,8 @@ class AiAgentLogParserTest {
                 parseFixture("codex-conversation.jsonl", CodexLogFormat.INSTANCE);
         long started = events.stream().filter(e -> "tool_call".equals(e.getCategory())).count();
         long completed = events.stream().filter(e -> "tool_result".equals(e.getCategory())).count();
-        assertEquals(2, started, "Fixture should keep both started commands visible");
-        assertEquals(
-                1, completed, "Only the command with aggregated output should render a result");
+        assertEquals(4, started, "Fixture should keep command and MCP starts visible");
+        assertEquals(3, completed, "Empty command completion should not render a result");
     }
 
     @Test
@@ -175,8 +176,12 @@ class AiAgentLogParserTest {
                         .filter(e -> "tool_result".equals(e.getCategory()))
                         .collect(Collectors.toList());
 
-        assertEquals(1, toolResults.size(), "Should have exactly 1 visible tool result");
-        assertTrue(toolResults.get(0).getToolOutput().contains("github.com-personal"));
+        assertEquals(3, toolResults.size(), "Should have 3 visible tool results");
+        assertTrue(toolResults.stream().anyMatch(e -> e.getToolOutput().contains("README.md")));
+        assertTrue(toolResults.stream().anyMatch(e -> e.getToolOutput().contains("sample-plugin")));
+        assertTrue(
+                toolResults.stream()
+                        .anyMatch(e -> e.getToolOutput().contains("No external resources")));
     }
 
     // ======================== Cursor Agent Tests ========================
@@ -666,7 +671,7 @@ class AiAgentLogParserTest {
     void codexConversation_hasCorrectEventCount() throws IOException {
         List<AiAgentLogParser.EventView> events =
                 parseFixture("codex-conversation.jsonl", CodexLogFormat.INSTANCE);
-        assertEquals(6, events.size(), "Current Codex fixture should produce 6 visible events");
+        assertEquals(11, events.size(), "Current Codex fixture should produce 11 visible events");
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRecordedConversationTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRecordedConversationTest.java
@@ -113,7 +113,7 @@ class AiAgentRecordedConversationTest {
         assertTrue(cats.contains("tool_call"), "Should have tool_call");
         assertTrue(cats.contains("tool_result"), "Should have tool_result");
         assertTrue(cats.contains("assistant"), "Should have assistant");
-        assertEquals(6, events.size(), "Current Codex fixture should render 6 visible events");
+        assertEquals(11, events.size(), "Current Codex fixture should render 11 visible events");
     }
 
     @Test

--- a/src/test/resources/io/jenkins/plugins/aiagentjob/fixtures/codex-conversation.jsonl
+++ b/src/test/resources/io/jenkins/plugins/aiagentjob/fixtures/codex-conversation.jsonl
@@ -1,11 +1,16 @@
-{"type":"thread.started","thread_id":"019cc652-ce98-79a3-a64b-1e266571e319"}
+{"type":"thread.started","thread_id":"codex-fixture-thread-01"}
 {"type":"turn.started"}
-{"type":"item.completed","item":{"id":"item_0","type":"reasoning","status":"completed","text":"I need to inspect the repo structure first."}}
-{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"I’ll summarize the repo end-to-end. First I’ll inspect the top-level docs and build files."}}
-{"type":"item.started","item":{"id":"item_2","type":"command_execution","command":"/bin/zsh -lc 'git remote -v'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
-{"type":"item.completed","item":{"id":"item_2","type":"command_execution","command":"/bin/zsh -lc 'git remote -v'","aggregated_output":"origin\tgit@github.com-personal:bvolpato/jenkins-ai-agent-plugin (fetch)\norigin\tgit@github.com-personal:bvolpato/jenkins-ai-agent-plugin (push)\n","exit_code":0,"status":"completed"}}
-{"type":"item.started","item":{"id":"item_3","type":"command_execution","command":"/bin/zsh -lc \"rg --files -g 'README*' -g 'pom.xml'\"","aggregated_output":"","exit_code":null,"status":"in_progress"}}
-{"type":"item.completed","item":{"id":"item_3","type":"command_execution","command":"/bin/zsh -lc \"rg --files -g 'README*' -g 'pom.xml'\"","aggregated_output":"","exit_code":0,"status":"completed"}}
-{"type":"item.started","item":{"id":"item_4","type":"agent_message","status":"in_progress","text":""}}
-{"type":"item.completed","item":{"id":"item_4","type":"agent_message","text":"I’ve got the required context. Next I’m reading the Java classes and Jenkins views to verify behavior beyond the README."}}
-{"type":"turn.completed","usage":{"input_tokens":1744750,"cached_input_tokens":1567488,"output_tokens":6375}}
+{"type":"item.completed","item":{"id":"item_0","type":"reasoning","status":"completed","text":"Need inspect build metadata, read tests, and validate without exposing private data."}}
+{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"I will inspect sanitized project files, run a focused check, then summarize findings."}}
+{"type":"item.started","item":{"id":"item_2","type":"command_execution","command":"/usr/bin/zsh -lc 'rg --files -g pom.xml -g README.md'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_2","type":"command_execution","command":"/usr/bin/zsh -lc 'rg --files -g pom.xml -g README.md'","aggregated_output":"README.md\npom.xml\n","exit_code":0,"status":"completed"}}
+{"type":"item.started","item":{"id":"item_3","type":"command_execution","command":"/usr/bin/zsh -lc 'sed -n '\\''1,80p'\\'' pom.xml'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_3","type":"command_execution","command":"/usr/bin/zsh -lc 'sed -n '\\''1,80p'\\'' pom.xml'","aggregated_output":"<project>\n  <artifactId>sample-plugin</artifactId>\n</project>\n","exit_code":0,"status":"completed"}}
+{"type":"item.started","item":{"id":"item_4","type":"command_execution","command":"/usr/bin/zsh -lc 'mvn -q -DskipTests package'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_4","type":"command_execution","command":"/usr/bin/zsh -lc 'mvn -q -DskipTests package'","aggregated_output":"","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_5","type":"reasoning","status":"completed","text":"Build metadata and targeted package step look consistent. Need include tool evidence in final answer."}}
+{"type":"item.started","item":{"id":"item_6","type":"mcp_tool_call","status":"in_progress","name":"list_mcp_resources","arguments":{"server":"docs"}}}
+{"type":"item.completed","item":{"id":"item_6","type":"mcp_tool_call","status":"completed","name":"list_mcp_resources","result":{"text":"No external resources used for this sanitized fixture."}}}
+{"type":"item.started","item":{"id":"item_7","type":"agent_message","status":"in_progress","text":""}}
+{"type":"item.completed","item":{"id":"item_7","type":"agent_message","text":"Validated sanitized project metadata and package command. No private paths, tokens, or user data were included."}}
+{"type":"turn.completed","usage":{"input_tokens":42581,"cached_input_tokens":30976,"output_tokens":108,"reasoning_output_tokens":49}}

--- a/src/test/resources/io/jenkins/plugins/aiagentjob/fixtures/stats-codex.jsonl
+++ b/src/test/resources/io/jenkins/plugins/aiagentjob/fixtures/stats-codex.jsonl
@@ -1,5 +1,4 @@
 {"type":"thread.started","thread_id":"test-codex-thread-01"}
 {"type":"turn.started"}
-{"type":"item.completed","item":{"id":"item_0","type":"reasoning","text":"Thinking about greeting"}}
-{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"hi!"}}
-{"type":"turn.completed","usage":{"input_tokens":25602,"cached_input_tokens":3456,"output_tokens":116}}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"OK"}}
+{"type":"turn.completed","usage":{"input_tokens":42581,"cached_input_tokens":30976,"output_tokens":108,"reasoning_output_tokens":49}}


### PR DESCRIPTION
## Summary

Updates Codex CLI integration for current `codex-cli 0.140.0` behavior and broadens Codex-focused coverage without copying real private trajectories.

## Changes

- Replace removed Codex `--full-auto` usage with current `--sandbox workspace-write --ask-for-approval never` global flags.
- Add Codex-specific global and exec arg fields for flags like `--search`, `--profile`, `--ephemeral`, `--ignore-user-config`, `--add-dir`, and `--output-schema`.
- Add shared reasoning effort field, wired to Codex (`model_reasoning_effort`), Claude Code (`--effort`), and OpenCode (`--variant`).
- Refresh Codex fixtures with sanitized richer JSONL trajectory and current `reasoning_output_tokens` usage.
- Update docs, including `gpt-5.5` Codex example.

## Testing

- `codex --help`
- `codex exec --help`
- `codex --version` -> `codex-cli 0.140.0`
- Tiny synthetic `codex --ask-for-approval never exec --json ...` samples for current JSONL shape
- `jq -e` over Codex fixtures
- `git diff --check`
- `mvn -B -ntp com.spotify.fmt:fmt-maven-plugin:format`
- `mvn -B -ntp -Dtest=AiAgentCommandFactoryTest,AiAgentLogParserTest,AgentUsageStatsTest,AiAgentRecordedConversationTest test`
- `mvn -B -ntp -Dtest=AiAgentCommandFactoryTest,AiAgentBuilderConfigRoundTripTest test`
- `mvn -B -ntp clean verify` -> 184 tests, 0 failures, 1 skipped

## Repro Command

```bash
mvn -B -ntp clean verify
```

## Did this cause any problems?

Rollback/revert this commit and redeploy the plugin.
