### PR TITLE
[opencode] Fix Jenkins approval flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ If the selected agent type has an associated credential ID (e.g., API key), the 
 
 When approvals are enabled and YOLO mode is off, tool calls detected in the agent's output trigger a blocking approval request. The build pauses until a user approves or denies from the build page. Denied or timed-out requests fail the build.
 
+OpenCode approval builds use its bidirectional Agent Client Protocol server. The installed OpenCode CLI must support `opencode acp`. OpenCode builds without manual approvals continue to use `opencode run`.
+
 ### Usage Statistics
 
 After a build completes, a statistics bar shows token usage, cost (when available), and duration. Data is extracted from the agent's own reporting in the JSONL log. The level of detail depends on the agent — Claude Code and OpenCode report full cost, while others report only token counts.

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AcpClientSession.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AcpClientSession.java
@@ -1,0 +1,305 @@
+package io.jenkins.plugins.aiagentjob;
+
+import hudson.Proc;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+/** Minimal synchronous Agent Client Protocol client for one agent prompt. */
+final class AcpClientSession {
+    private static final String JSONRPC_VERSION = "2.0";
+
+    private final Proc proc;
+    private final BufferedReader reader;
+    private final BufferedWriter writer;
+    private final AiAgentExecutor.AgentOutputHandler outputHandler;
+    private final ExecutionRegistry.LiveExecution liveExecution;
+    private final Duration approvalTimeout;
+    private long nextRequestId;
+
+    AcpClientSession(
+            Proc proc,
+            InputStream stdout,
+            OutputStream stdin,
+            AiAgentExecutor.AgentOutputHandler outputHandler,
+            ExecutionRegistry.LiveExecution liveExecution,
+            Duration approvalTimeout) {
+        this.proc = proc;
+        this.reader = new BufferedReader(new InputStreamReader(stdout, StandardCharsets.UTF_8));
+        this.writer = new BufferedWriter(new OutputStreamWriter(stdin, StandardCharsets.UTF_8));
+        this.outputHandler = outputHandler;
+        this.liveExecution = liveExecution;
+        this.approvalTimeout = approvalTimeout;
+    }
+
+    boolean execute(String cwd, String prompt, String model, String reasoningEffort)
+            throws IOException, InterruptedException {
+        try {
+            initialize();
+            String sessionId = newSession(cwd);
+            setConfigOption(sessionId, "model", model);
+            setConfigOption(sessionId, "effort", reasoningEffort);
+            prompt(sessionId, prompt);
+            return true;
+        } catch (ApprovalDeniedException e) {
+            return false;
+        }
+    }
+
+    private void initialize() throws IOException, InterruptedException {
+        JSONObject fileSystem = object("readTextFile", false, "writeTextFile", false);
+        JSONObject capabilities = object("fs", fileSystem, "terminal", false);
+        JSONObject params = object("protocolVersion", 1, "clientCapabilities", capabilities);
+        request("initialize", params);
+    }
+
+    private String newSession(String cwd) throws IOException, InterruptedException {
+        JSONObject params = object("cwd", cwd, "mcpServers", new JSONArray());
+        JSONObject result = request("session/new", params);
+        String sessionId = result.optString("sessionId", "").trim();
+        if (sessionId.isEmpty()) {
+            throw new IOException("ACP agent returned no session ID.");
+        }
+        return sessionId;
+    }
+
+    private void setConfigOption(String sessionId, String configId, String value)
+            throws IOException, InterruptedException {
+        if (value == null || value.trim().isEmpty()) {
+            return;
+        }
+        JSONObject params =
+                object("sessionId", sessionId, "configId", configId, "value", value.trim());
+        request("session/set_config_option", params);
+    }
+
+    private void prompt(String sessionId, String prompt) throws IOException, InterruptedException {
+        JSONArray content = new JSONArray();
+        content.add(object("type", "text", "text", prompt));
+        request("session/prompt", object("sessionId", sessionId, "prompt", content));
+    }
+
+    private JSONObject request(String method, JSONObject params)
+            throws IOException, InterruptedException {
+        long requestId = ++nextRequestId;
+        send(
+                object(
+                        "jsonrpc",
+                        JSONRPC_VERSION,
+                        "id",
+                        requestId,
+                        "method",
+                        method,
+                        "params",
+                        params));
+
+        while (true) {
+            JSONObject message = readMessage();
+            String incomingMethod = message.optString("method", "");
+            if ("session/request_permission".equals(incomingMethod) && message.has("id")) {
+                handlePermissionRequest(message);
+                continue;
+            }
+            if (!incomingMethod.isEmpty() && message.has("id")) {
+                sendMethodNotFound(message.opt("id"), incomingMethod);
+                continue;
+            }
+            if (!sameId(message.opt("id"), requestId)) {
+                continue;
+            }
+
+            JSONObject error = message.optJSONObject("error");
+            if (error != null) {
+                outputHandler.recordLine(message.toString());
+                String errorMessage = error.optString("message", error.toString());
+                throw new IOException("ACP " + method + " failed: " + errorMessage);
+            }
+            JSONObject result = message.optJSONObject("result");
+            if (result == null) {
+                throw new IOException("ACP " + method + " returned no result.");
+            }
+            if ("session/prompt".equals(method)) {
+                outputHandler.recordLine(message.toString());
+            }
+            return result;
+        }
+    }
+
+    private JSONObject readMessage() throws IOException, InterruptedException {
+        while (true) {
+            String line = reader.readLine();
+            if (line == null) {
+                int exitCode = proc.join();
+                throw new IOException(
+                        "ACP agent exited with code " + exitCode + " before completing request.");
+            }
+            String trimmed = line.trim();
+            if (!trimmed.startsWith("{")) {
+                outputHandler.recordLine(line);
+                continue;
+            }
+            try {
+                JSONObject message = JSONObject.fromObject(trimmed);
+                if (shouldRecord(message)) {
+                    outputHandler.recordLine(line);
+                }
+                return message;
+            } catch (RuntimeException e) {
+                outputHandler.recordLine(line);
+                throw new IOException("ACP agent returned invalid JSON: " + trimmed, e);
+            }
+        }
+    }
+
+    private static boolean shouldRecord(JSONObject message) {
+        String method = message.optString("method", "");
+        if ("session/request_permission".equals(method)) {
+            return true;
+        }
+        if (!"session/update".equals(method)) {
+            return false;
+        }
+        JSONObject params = message.optJSONObject("params");
+        JSONObject update = params == null ? null : params.optJSONObject("update");
+        if (update == null) {
+            return false;
+        }
+        String type = update.optString("sessionUpdate", "");
+        return "agent_message_chunk".equals(type)
+                || "user_message_chunk".equals(type)
+                || "agent_thought_chunk".equals(type)
+                || "tool_call".equals(type)
+                || "tool_call_update".equals(type)
+                || "usage_update".equals(type);
+    }
+
+    private void handlePermissionRequest(JSONObject request)
+            throws IOException, InterruptedException {
+        JSONObject params = request.optJSONObject("params");
+        JSONObject toolCall = params == null ? null : params.optJSONObject("toolCall");
+        if (params == null || toolCall == null) {
+            sendMethodNotFound(request.opt("id"), "session/request_permission");
+            return;
+        }
+
+        String toolCallId =
+                LogFormatUtils.firstNonEmpty(toolCall, "toolCallId", "tool_call_id", "id");
+        if (toolCallId.isEmpty()) {
+            toolCallId = String.valueOf(request.opt("id"));
+        }
+        String toolName = LogFormatUtils.firstNonEmpty(toolCall, "kind", "title");
+        if (toolName.isEmpty()) {
+            toolName = "tool";
+        }
+        JSONObject rawInput = toolCall.optJSONObject("rawInput");
+        String summary = LogFormatUtils.extractToolInput(rawInput, toolName);
+        if (summary.isEmpty()) {
+            summary = LogFormatUtils.firstNonEmpty(toolCall, "title");
+        }
+
+        ExecutionRegistry.PendingApproval pending =
+                liveExecution.createPendingApproval(toolCallId, toolName, summary);
+        outputHandler.writeStatus(
+                "Approval required: "
+                        + pending.getToolName()
+                        + " ("
+                        + pending.getToolCallId()
+                        + ")");
+
+        ExecutionRegistry.ApprovalDecision decision =
+                liveExecution.awaitDecision(pending, approvalTimeout);
+        JSONArray options = params.optJSONArray("options");
+        String optionId =
+                findPermissionOption(
+                        options,
+                        decision.isApproved()
+                                ? new String[] {"allow_once"}
+                                : new String[] {"reject_once", "reject_always"});
+        boolean approved = decision.isApproved() && optionId != null;
+
+        JSONObject outcome;
+        if (optionId == null) {
+            outcome = object("outcome", "cancelled");
+        } else {
+            outcome = object("outcome", "selected", "optionId", optionId);
+        }
+        send(
+                object(
+                        "jsonrpc",
+                        JSONRPC_VERSION,
+                        "id",
+                        request.opt("id"),
+                        "result",
+                        object("outcome", outcome)));
+
+        if (!approved) {
+            String reason =
+                    decision.isApproved()
+                            ? "agent did not offer an allow-once option"
+                            : decision.getReason();
+            outputHandler.writeStatus("Approval denied: " + reason);
+            throw new ApprovalDeniedException();
+        }
+        outputHandler.writeStatus("Approval granted: " + pending.getToolName());
+    }
+
+    private static String findPermissionOption(JSONArray options, String[] acceptedKinds) {
+        if (options == null) {
+            return null;
+        }
+        for (String acceptedKind : acceptedKinds) {
+            for (int i = 0; i < options.size(); i++) {
+                Object item = options.get(i);
+                if (!(item instanceof JSONObject)) {
+                    continue;
+                }
+                JSONObject option = (JSONObject) item;
+                if (acceptedKind.equals(option.optString("kind", ""))) {
+                    String optionId = option.optString("optionId", "").trim();
+                    if (!optionId.isEmpty()) {
+                        return optionId;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private void sendMethodNotFound(Object id, String method) throws IOException {
+        JSONObject error =
+                object("code", -32601, "message", "Unsupported ACP client method: " + method);
+        send(object("jsonrpc", JSONRPC_VERSION, "id", id, "error", error));
+    }
+
+    private synchronized void send(JSONObject message) throws IOException {
+        writer.write(message.toString());
+        writer.newLine();
+        writer.flush();
+    }
+
+    private static boolean sameId(Object value, long expected) {
+        return value != null && String.valueOf(expected).equals(String.valueOf(value));
+    }
+
+    private static JSONObject object(Object... values) {
+        JSONObject result = new JSONObject();
+        for (int i = 0; i < values.length; i += 2) {
+            result.put(String.valueOf(values[i]), values[i + 1]);
+        }
+        return result;
+    }
+
+    private static final class ApprovalDeniedException extends IOException {
+        private static final long serialVersionUID = 1L;
+    }
+}

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -11,12 +11,14 @@ import hudson.Util;
 import hudson.console.LineTransformationOutputStream;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.util.StreamCopyThread;
 
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
@@ -28,6 +30,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -104,16 +107,24 @@ final class AiAgentExecutor {
                 config.getAgent().prepareExecution(config, workspace, listener);
         procEnv.putAll(executionCustomization.getEnvironment());
 
+        AiAgentTypeHandler.AcpExecutionSpec acpExecution =
+                commandOverride.isEmpty() && config.isRequireApprovals() && !config.isYoloMode()
+                        ? config.getAgent().buildAcpExecution(config)
+                        : null;
+
         List<String> agentCommand;
         if (!commandOverride.isEmpty()) {
             agentCommand = List.of(commandOverride);
+        } else if (acpExecution != null) {
+            agentCommand = acpExecution.getCommand();
         } else {
             agentCommand = AiAgentCommandFactory.buildDefaultCommand(config, prompt);
         }
 
         boolean needsShellEnvironmentBootstrap =
                 launcher.isUnix() && !executionCustomization.getEnvironment().isEmpty();
-        boolean forceUnixShell = config.isDisableInteractive() && launcher.isUnix();
+        boolean disableInteractive = config.isDisableInteractive() && acpExecution == null;
+        boolean forceUnixShell = disableInteractive && launcher.isUnix();
         List<String> command;
         FilePath tempSetupScript = null;
         if ((!setupScript.isEmpty() && launcher.isUnix())
@@ -125,7 +136,7 @@ final class AiAgentExecutor {
                             executionCustomization.getEnvironment(),
                             agentCommand,
                             commandOverride,
-                            config.isDisableInteractive());
+                            disableInteractive);
             tempSetupScript = writeTempScript(workspace, combinedScript);
             command = buildShellCommand(combinedScript, tempSetupScript);
         } else if (!commandOverride.isEmpty()) {
@@ -134,7 +145,7 @@ final class AiAgentExecutor {
                 command = List.of("/bin/sh", "-c", commandOverride);
             } else {
                 String cmd = commandOverride;
-                if (config.isDisableInteractive() && !cmd.toUpperCase().contains("< NUL")) {
+                if (disableInteractive && !cmd.toUpperCase().contains("< NUL")) {
                     cmd =
                             cmd.endsWith("\n")
                                     ? cmd.substring(0, cmd.length() - 1) + " < NUL\n"
@@ -142,7 +153,7 @@ final class AiAgentExecutor {
                 }
                 command = List.of("cmd", "/c", cmd);
             }
-        } else if (config.isDisableInteractive()) {
+        } else if (disableInteractive) {
             command =
                     List.of(
                             "cmd",
@@ -182,7 +193,7 @@ final class AiAgentExecutor {
                         listener.getLogger(),
                         rawLogFile,
                         liveExecution,
-                        config.isRequireApprovals() && !config.isYoloMode(),
+                        config.isRequireApprovals() && !config.isYoloMode() && acpExecution == null,
                         approvalTimeout,
                         config.getAgent().getLogFormat());
         OutputStream stdoutSink = new NonClosingSynchronizedOutputStream(outputHandler);
@@ -190,17 +201,32 @@ final class AiAgentExecutor {
 
         int exitCode;
         try {
-            Proc proc =
-                    launcher.launch()
-                            .cmds(command)
-                            .pwd(runDirectory)
-                            .envs(procEnv)
-                            .stdout(stdoutSink)
-                            .stderr(stderrSink)
-                            .quiet(true)
-                            .start();
-            outputHandler.attach(proc);
-            exitCode = proc.join();
+            if (acpExecution != null) {
+                exitCode =
+                        executeAcpProcess(
+                                launcher,
+                                command,
+                                runDirectory,
+                                procEnv,
+                                listener,
+                                outputHandler,
+                                liveExecution,
+                                approvalTimeout,
+                                prompt,
+                                acpExecution);
+            } else {
+                Proc proc =
+                        launcher.launch()
+                                .cmds(command)
+                                .pwd(runDirectory)
+                                .envs(procEnv)
+                                .stdout(stdoutSink)
+                                .stderr(stderrSink)
+                                .quiet(true)
+                                .start();
+                outputHandler.attach(proc);
+                exitCode = proc.join();
+            }
         } finally {
             outputHandler.close();
             ExecutionRegistry.unregister(run, invocationId);
@@ -222,6 +248,69 @@ final class AiAgentExecutor {
         }
         action.markCompleted(invocationId, exitCode);
         return exitCode;
+    }
+
+    private static int executeAcpProcess(
+            Launcher launcher,
+            List<String> command,
+            FilePath runDirectory,
+            EnvVars procEnv,
+            TaskListener listener,
+            AgentOutputHandler outputHandler,
+            ExecutionRegistry.LiveExecution liveExecution,
+            Duration approvalTimeout,
+            String prompt,
+            AiAgentTypeHandler.AcpExecutionSpec acpExecution)
+            throws IOException, InterruptedException {
+        Proc proc =
+                launcher.launch()
+                        .cmds(command)
+                        .pwd(runDirectory)
+                        .envs(procEnv)
+                        .readStdout()
+                        .readStderr()
+                        .writeStdin()
+                        .quiet(true)
+                        .start();
+        outputHandler.attach(proc);
+
+        InputStream stdout = proc.getStdout();
+        InputStream stderr = proc.getStderr();
+        OutputStream stdin = proc.getStdin();
+        if (stdout == null || stderr == null || stdin == null) {
+            proc.kill();
+            throw new IOException("Jenkins launcher did not provide ACP process streams.");
+        }
+
+        StreamCopyThread stderrThread =
+                new StreamCopyThread(
+                        "ai-agent-acp-stderr",
+                        stderr,
+                        new NonClosingSynchronizedOutputStream(outputHandler),
+                        false);
+        stderrThread.start();
+        try {
+            AcpClientSession session =
+                    new AcpClientSession(
+                            proc, stdout, stdin, outputHandler, liveExecution, approvalTimeout);
+            return session.execute(
+                            runDirectory.getRemote(),
+                            prompt,
+                            acpExecution.getModel(),
+                            acpExecution.getReasoningEffort())
+                    ? 0
+                    : 1;
+        } finally {
+            try {
+                stdin.close();
+            } finally {
+                if (proc.isAlive()) {
+                    proc.kill();
+                }
+                proc.joinWithTimeout(10, TimeUnit.SECONDS, listener);
+                stderrThread.join(TimeUnit.SECONDS.toMillis(10));
+            }
+        }
     }
 
     private static String buildCombinedScript(
@@ -380,7 +469,7 @@ final class AiAgentExecutor {
         public void close() {}
     }
 
-    private static final class AgentOutputHandler extends LineTransformationOutputStream {
+    static final class AgentOutputHandler extends LineTransformationOutputStream {
         private final OutputStream logger;
         private final BufferedWriter rawWriter;
         private final ExecutionRegistry.LiveExecution liveExecution;
@@ -422,6 +511,11 @@ final class AiAgentExecutor {
         @Override
         protected synchronized void eol(byte[] b, int len) throws IOException {
             String line = new String(b, 0, len, StandardCharsets.UTF_8);
+            recordLine(line);
+        }
+
+        synchronized void recordLine(String rawLine) throws IOException {
+            String line = rawLine;
             if (line.endsWith("\r")) {
                 line = line.substring(0, line.length() - 1);
             }
@@ -450,23 +544,18 @@ final class AiAgentExecutor {
                             parsedLine.getToolCallIdOrGenerated(),
                             parsedLine.getToolName(),
                             parsedLine.getSummary());
-            logger.write(
-                    ("[ai-agent] Approval required: "
-                                    + pending.getToolName()
-                                    + " ("
-                                    + pending.getToolCallId()
-                                    + ")\n")
-                            .getBytes(StandardCharsets.UTF_8));
-            logger.flush();
+            writeStatus(
+                    "Approval required: "
+                            + pending.getToolName()
+                            + " ("
+                            + pending.getToolCallId()
+                            + ")");
 
             ExecutionRegistry.ApprovalDecision decision =
                     liveExecution.awaitDecision(pending, approvalTimeout);
             if (!decision.isApproved()) {
                 deniedByApproval = true;
-                logger.write(
-                        ("[ai-agent] Approval denied: " + decision.getReason() + "\n")
-                                .getBytes(StandardCharsets.UTF_8));
-                logger.flush();
+                writeStatus("Approval denied: " + decision.getReason());
                 Proc currentProc = this.proc;
                 if (currentProc != null) {
                     try {
@@ -476,11 +565,13 @@ final class AiAgentExecutor {
                     }
                 }
             } else {
-                logger.write(
-                        ("[ai-agent] Approval granted: " + pending.getToolName() + "\n")
-                                .getBytes(StandardCharsets.UTF_8));
-                logger.flush();
+                writeStatus("Approval granted: " + pending.getToolName());
             }
+        }
+
+        synchronized void writeStatus(String message) throws IOException {
+            logger.write(("[ai-agent] " + message + "\n").getBytes(StandardCharsets.UTF_8));
+            logger.flush();
         }
 
         @Override

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentTypeHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentTypeHandler.java
@@ -33,6 +33,14 @@ public abstract class AiAgentTypeHandler extends AbstractDescribableImpl<AiAgent
 
     public abstract List<String> buildDefaultCommand(AiAgentConfiguration config, String prompt);
 
+    /**
+     * Returns an ACP server command when this agent needs a bidirectional approval channel, or
+     * {@code null} when its normal command handles approvals directly.
+     */
+    public AcpExecutionSpec buildAcpExecution(AiAgentConfiguration config) {
+        return null;
+    }
+
     public AiAgentExecutionCustomization prepareExecution(
             AiAgentConfiguration config, FilePath workspace, TaskListener listener)
             throws IOException, InterruptedException {
@@ -55,4 +63,29 @@ public abstract class AiAgentTypeHandler extends AbstractDescribableImpl<AiAgent
      * false} for any JSON it does not recognise, so the shared extractor handles it as a fallback.
      */
     public abstract AiAgentStatsExtractor getStatsExtractor();
+
+    /** Immutable settings for an Agent Client Protocol execution. */
+    public static final class AcpExecutionSpec {
+        private final List<String> command;
+        private final String model;
+        private final String reasoningEffort;
+
+        public AcpExecutionSpec(List<String> command, String model, String reasoningEffort) {
+            this.command = command == null ? List.of() : List.copyOf(command);
+            this.model = model == null ? "" : model;
+            this.reasoningEffort = reasoningEffort == null ? "" : reasoningEffort;
+        }
+
+        public List<String> getCommand() {
+            return command;
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public String getReasoningEffort() {
+            return reasoningEffort;
+        }
+    }
 }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeAgentHandler.java
@@ -16,6 +16,7 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public final class OpenCodeAgentHandler extends AiAgentTypeHandler {
@@ -51,6 +52,53 @@ public final class OpenCodeAgentHandler extends AiAgentTypeHandler {
         }
         command.add(prompt);
         return command;
+    }
+
+    @Override
+    public AcpExecutionSpec buildAcpExecution(AiAgentConfiguration config) {
+        List<String> command = new ArrayList<>();
+        command.add("opencode");
+        command.add("acp");
+
+        String model = Util.fixNull(config.getModel()).trim();
+        String reasoningEffort = Util.fixNull(config.getReasoningEffort()).trim();
+        List<String> extraArgs =
+                new ArrayList<>(Arrays.asList(Util.tokenize(Util.fixNull(config.getExtraArgs()))));
+        for (int i = 0; i < extraArgs.size(); i++) {
+            String arg = extraArgs.get(i);
+            if ("--model".equals(arg) || "-m".equals(arg)) {
+                if (i + 1 < extraArgs.size()) {
+                    model = extraArgs.get(++i);
+                }
+                continue;
+            }
+            if (arg.startsWith("--model=")) {
+                model = arg.substring("--model=".length());
+                continue;
+            }
+            if ("--variant".equals(arg)) {
+                if (i + 1 < extraArgs.size()) {
+                    reasoningEffort = extraArgs.get(++i);
+                }
+                continue;
+            }
+            if (arg.startsWith("--variant=")) {
+                reasoningEffort = arg.substring("--variant=".length());
+                continue;
+            }
+            if ("--format".equals(arg)) {
+                if (i + 1 < extraArgs.size()) {
+                    i++;
+                }
+                continue;
+            }
+            if (arg.startsWith("--format=")) {
+                continue;
+            }
+            command.add(arg);
+        }
+
+        return new AcpExecutionSpec(command, model, reasoningEffort);
     }
 
     @Override

--- a/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeLogFormat.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeLogFormat.java
@@ -8,8 +8,8 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 /**
- * Format-specific log classification for OpenCode JSONL output. Handles part-based events for text
- * and tool use with nested state objects.
+ * Format-specific log classification for OpenCode JSONL and ACP output. Handles part-based run
+ * events plus ACP message, tool, and result updates.
  */
 public final class OpenCodeLogFormat implements AiAgentLogFormat {
 
@@ -19,6 +19,11 @@ public final class OpenCodeLogFormat implements AiAgentLogFormat {
 
     @Override
     public AiAgentLogParser.ParsedLine classify(long lineNumber, JSONObject json) {
+        AiAgentLogParser.ParsedLine acpLine = classifyAcpEvent(lineNumber, json);
+        if (acpLine != null) {
+            return acpLine;
+        }
+
         String type = LogFormatUtils.firstNonEmpty(json, "type", "event", "kind", "subtype");
         String typeLower = LogFormatUtils.normalize(type);
 
@@ -34,6 +39,129 @@ public final class OpenCodeLogFormat implements AiAgentLogFormat {
         }
 
         return null;
+    }
+
+    private static AiAgentLogParser.ParsedLine classifyAcpEvent(long lineNumber, JSONObject json) {
+        String method = json.optString("method", "");
+        String rawDetails = json.toString(2);
+        if ("session/request_permission".equals(method)) {
+            return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
+        }
+        if ("session/update".equals(method)) {
+            JSONObject params = json.optJSONObject("params");
+            JSONObject update = params == null ? null : params.optJSONObject("update");
+            if (update == null) {
+                return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
+            }
+            return classifyAcpUpdate(lineNumber, update, rawDetails);
+        }
+
+        JSONObject result = json.optJSONObject("result");
+        String stopReason = LogFormatUtils.firstNonEmpty(result, "stopReason", "stop_reason");
+        if (!stopReason.isEmpty()) {
+            return AiAgentLogParser.ParsedLine.result(
+                    lineNumber,
+                    "result",
+                    "Result",
+                    LogFormatUtils.capitalize(stopReason),
+                    rawDetails);
+        }
+        return null;
+    }
+
+    private static AiAgentLogParser.ParsedLine classifyAcpUpdate(
+            long lineNumber, JSONObject update, String rawDetails) {
+        String updateType = LogFormatUtils.normalize(update.optString("sessionUpdate", ""));
+        JSONObject content = update.optJSONObject("content");
+        String text = content == null ? "" : LogFormatUtils.extractText(content);
+
+        if ("agent_message_chunk".equals(updateType)) {
+            return AiAgentLogParser.ParsedLine.message(
+                    lineNumber, "assistant", "Assistant", text, rawDetails, true);
+        }
+        if ("user_message_chunk".equals(updateType)) {
+            return AiAgentLogParser.ParsedLine.message(
+                    lineNumber, "user", "User", text, rawDetails);
+        }
+        if ("agent_thought_chunk".equals(updateType)) {
+            return AiAgentLogParser.ParsedLine.thinking(lineNumber, text, rawDetails);
+        }
+        if ("tool_call".equals(updateType)) {
+            return classifyAcpToolCall(lineNumber, update, rawDetails);
+        }
+        if ("tool_call_update".equals(updateType)) {
+            return classifyAcpToolUpdate(lineNumber, update, rawDetails);
+        }
+        return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
+    }
+
+    private static AiAgentLogParser.ParsedLine classifyAcpToolCall(
+            long lineNumber, JSONObject update, String rawDetails) {
+        String toolName = LogFormatUtils.firstNonEmpty(update, "kind", "title");
+        String toolCallId =
+                LogFormatUtils.firstNonEmpty(update, "toolCallId", "tool_call_id", "id");
+        String input = LogFormatUtils.extractToolInput(update.optJSONObject("rawInput"), toolName);
+        if (input.isEmpty()) {
+            input = LogFormatUtils.firstNonEmpty(update, "title");
+        }
+        if (input.isEmpty()) {
+            return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
+        }
+        return AiAgentLogParser.ParsedLine.toolCall(
+                lineNumber, toolName, input, rawDetails, toolCallId);
+    }
+
+    private static AiAgentLogParser.ParsedLine classifyAcpToolUpdate(
+            long lineNumber, JSONObject update, String rawDetails) {
+        String status = LogFormatUtils.normalize(update.optString("status", ""));
+        if (!"completed".equals(status) && !"failed".equals(status)) {
+            return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
+        }
+
+        String toolName = LogFormatUtils.firstNonEmpty(update, "kind", "title");
+        String toolCallId =
+                LogFormatUtils.firstNonEmpty(update, "toolCallId", "tool_call_id", "id");
+        String output = extractAcpToolOutput(update);
+        if (output.isEmpty()) {
+            return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
+        }
+        return AiAgentLogParser.ParsedLine.toolResult(
+                lineNumber, toolName, output, rawDetails, toolCallId);
+    }
+
+    private static String extractAcpToolOutput(JSONObject update) {
+        JSONArray content = update.optJSONArray("content");
+        if (content != null) {
+            StringBuilder output = new StringBuilder();
+            for (int i = 0; i < content.size(); i++) {
+                Object item = content.get(i);
+                if (!(item instanceof JSONObject)) {
+                    continue;
+                }
+                JSONObject itemObject = (JSONObject) item;
+                JSONObject nestedContent = itemObject.optJSONObject("content");
+                String text =
+                        nestedContent == null ? "" : LogFormatUtils.extractText(nestedContent);
+                if (!text.isEmpty()) {
+                    if (output.length() > 0) {
+                        output.append('\n');
+                    }
+                    output.append(text);
+                }
+            }
+            if (output.length() > 0) {
+                return output.toString();
+            }
+        }
+
+        Object rawOutput = update.opt("rawOutput");
+        if (rawOutput instanceof String) {
+            return (String) rawOutput;
+        }
+        if (rawOutput instanceof JSONObject && !((JSONObject) rawOutput).isEmpty()) {
+            return ((JSONObject) rawOutput).toString(2);
+        }
+        return "";
     }
 
     static AiAgentLogParser.ParsedLine classifyPartEvent(

--- a/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeStatsExtractor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeStatsExtractor.java
@@ -8,9 +8,8 @@ import net.sf.json.JSONObject;
 import java.util.Locale;
 
 /**
- * Stats extractor for OpenCode JSONL output. OpenCode reports per-step usage in "step_finish"
- * events with a nested "part" object containing cost, tokens, and cache data. Values are
- * accumulated additively across multiple steps.
+ * Stats extractor for OpenCode output. Run mode reports additive per-step usage; ACP mode reports
+ * cumulative context and cost updates.
  */
 public final class OpenCodeStatsExtractor implements AiAgentStatsExtractor {
 
@@ -20,6 +19,21 @@ public final class OpenCodeStatsExtractor implements AiAgentStatsExtractor {
 
     @Override
     public boolean extract(JSONObject json, AgentUsageStats stats) {
+        if ("session/update".equals(json.optString("method", ""))) {
+            JSONObject params = json.optJSONObject("params");
+            JSONObject update = params == null ? null : params.optJSONObject("update");
+            if (update != null && "usage_update".equals(update.optString("sessionUpdate", ""))) {
+                long used = update.optLong("used", 0);
+                stats.addInputTokens(used);
+                stats.addTotalTokens(used);
+                JSONObject cost = update.optJSONObject("cost");
+                if (cost != null && "USD".equalsIgnoreCase(cost.optString("currency", ""))) {
+                    stats.addCostUsd(cost.optDouble("amount", 0));
+                }
+                return true;
+            }
+        }
+
         String type = json.optString("type", "").toLowerCase(Locale.ROOT);
 
         if ("step_finish".equals(type)) {

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AgentUsageStatsTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AgentUsageStatsTest.java
@@ -140,6 +140,24 @@ class AgentUsageStatsTest {
         assertEquals(0.005 + 0.003, stats.getCostUsd(), 0.0001);
     }
 
+    @Test
+    void openCode_acpUsageUsesLatestCumulativeValues() {
+        AgentUsageStats stats = new AgentUsageStats();
+        JSONObject first =
+                JSONObject.fromObject(
+                        "{\"method\":\"session/update\",\"params\":{\"update\":{\"sessionUpdate\":\"usage_update\",\"used\":40,\"cost\":{\"amount\":0.01,\"currency\":\"USD\"}}}}");
+        JSONObject second =
+                JSONObject.fromObject(
+                        "{\"method\":\"session/update\",\"params\":{\"update\":{\"sessionUpdate\":\"usage_update\",\"used\":55,\"cost\":{\"amount\":0.02,\"currency\":\"USD\"}}}}");
+
+        stats.extractFrom(first, OpenCodeStatsExtractor.INSTANCE);
+        stats.extractFrom(second, OpenCodeStatsExtractor.INSTANCE);
+
+        assertEquals(55, stats.getInputTokens());
+        assertEquals(55, stats.getTotalTokens());
+        assertEquals(0.02, stats.getCostUsd(), 0.0001);
+    }
+
     // ======================== Cursor ========================
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
@@ -12,11 +12,13 @@ import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
+import hudson.model.queue.QueueTaskFuture;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.WorkspaceList;
 
 import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeAgentHandler;
 import io.jenkins.plugins.aiagentjob.codex.CodexAgentHandler;
+import io.jenkins.plugins.aiagentjob.opencode.OpenCodeAgentHandler;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
@@ -25,7 +27,10 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import java.io.File;
+import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.concurrent.TimeUnit;
 
 @WithJenkins
 class AiAgentBuildExecutionTest {
@@ -240,6 +245,105 @@ class AiAgentBuildExecutionTest {
         AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
         assertNotNull(action);
         assertTrue(action.getEvents().stream().anyMatch(e -> "tool_call".equals(e.getCategory())));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void openCodeAcp_waitsForJenkinsApprovalBeforeToolExecution(JenkinsRule jenkins)
+            throws Exception {
+        File fakeBin = new File(jenkins.jenkins.getRootDir(), "fake-opencode-bin");
+        assertTrue(fakeBin.mkdirs());
+        File fakeOpenCode = new File(fakeBin, "opencode");
+        try (InputStream fixture =
+                getClass()
+                        .getResourceAsStream(
+                                "/io/jenkins/plugins/aiagentjob/fixtures/fake-opencode-acp.sh")) {
+            assertNotNull(fixture);
+            Files.copy(fixture, fakeOpenCode.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+        assertTrue(fakeOpenCode.setExecutable(true));
+
+        String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-opencode-acp-approval",
+                        b -> {
+                            b.setAgent(new OpenCodeAgentHandler());
+                            b.setPrompt("create approved.txt");
+                            b.setRequireApprovals(true);
+                            b.setApprovalTimeoutSeconds(30);
+                            b.setModel("test/provider-model");
+                            b.setExtraArgs("--variant high --format json --pure");
+                            b.setSetupScript("cd \"${WORKSPACE}\"");
+                            b.setEnvironmentVariables("PATH=" + path);
+                            b.setFailOnAgentError(true);
+                        });
+        DumbSlave agent = jenkins.createOnlineSlave();
+        project.setAssignedNode(agent);
+
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0);
+        assertNotNull(future);
+        FreeStyleBuild runningBuild = future.waitForStart();
+        ExecutionRegistry.PendingApproval pending =
+                waitForPendingApproval(jenkins, runningBuild, future);
+        AiAgentRunAction action = runningBuild.getAction(AiAgentRunAction.class);
+        assertNotNull(action);
+        ExecutionRegistry.LiveExecution liveExecution =
+                ExecutionRegistry.get(runningBuild, action.getLatestInvocationId());
+        assertNotNull(liveExecution);
+        FilePath runningWorkspace = runningBuild.getWorkspace();
+        assertNotNull(runningWorkspace);
+        assertFalse(runningWorkspace.child("approved.txt").exists());
+        assertTrue(liveExecution.approve(pending.getId()));
+
+        FreeStyleBuild build = future.get(20, TimeUnit.SECONDS);
+        jenkins.assertBuildStatusSuccess(build);
+        FilePath buildWorkspace = build.getWorkspace();
+        assertNotNull(buildWorkspace);
+        assertTrue(buildWorkspace.child("approved.txt").exists());
+        assertTrue(
+                buildWorkspace
+                        .child("approval-response.json")
+                        .readToString()
+                        .contains("\"optionId\":\"once\""));
+        String configRequests = buildWorkspace.child("config-requests.jsonl").readToString();
+        assertTrue(
+                configRequests.contains(
+                        "\"configId\":\"model\",\"value\":\"test/provider-model\""));
+        assertTrue(configRequests.contains("\"configId\":\"effort\",\"value\":\"high\""));
+        assertTrue(buildWorkspace.child("acp-command.txt").readToString().contains("acp --pure"));
+
+        String rawLog = Files.readString(action.getRawLogFile().toPath());
+        assertTrue(rawLog.contains("session/request_permission"));
+        assertFalse(rawLog.contains("\"configOptions\""));
+        assertFalse(rawLog.contains("private-test-command"));
+        assertFalse(rawLog.contains("private-test-content"));
+        assertTrue(action.getEvents().stream().anyMatch(e -> "tool_call".equals(e.getCategory())));
+        assertTrue(action.getEvents().stream().anyMatch(e -> "assistant".equals(e.getCategory())));
+    }
+
+    private static ExecutionRegistry.PendingApproval waitForPendingApproval(
+            JenkinsRule jenkins, FreeStyleBuild build, QueueTaskFuture<FreeStyleBuild> future)
+            throws Exception {
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (System.nanoTime() < deadline) {
+            AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
+            int invocationId = action == null ? 0 : action.getLatestInvocationId();
+            ExecutionRegistry.LiveExecution liveExecution =
+                    invocationId == 0 ? null : ExecutionRegistry.get(build, invocationId);
+            if (liveExecution != null && !liveExecution.getPendingApprovals().isEmpty()) {
+                return liveExecution.getPendingApprovals().get(0);
+            }
+            if (future.isDone()) {
+                FreeStyleBuild completed = future.get();
+                throw new AssertionError(
+                        "OpenCode ACP build completed before requesting approval:\n"
+                                + jenkins.getLog(completed));
+            }
+            Thread.sleep(50);
+        }
+        throw new AssertionError("OpenCode ACP approval request did not reach Jenkins.");
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
@@ -292,6 +292,21 @@ class AiAgentCommandFactoryTest {
         assertEquals("max", cmd.get(variantIdx + 1));
     }
 
+    @Test
+    void openCode_acpExecutionMapsRunOptionsToSessionConfig() {
+        OpenCodeAgentHandler handler = new OpenCodeAgentHandler();
+        AiAgentBuilder project = createProject(handler);
+        project.setModel("opencode/provider-model");
+        project.setReasoningEffort("high");
+        project.setExtraArgs("--model override/model --variant=xhigh --format json --pure");
+
+        AiAgentTypeHandler.AcpExecutionSpec execution = handler.buildAcpExecution(project);
+
+        assertEquals(List.of("opencode", "acp", "--pure"), execution.getCommand());
+        assertEquals("override/model", execution.getModel());
+        assertEquals("xhigh", execution.getReasoningEffort());
+    }
+
     // ======================== Gemini CLI Command Tests ========================
 
     @Test

--- a/src/test/resources/io/jenkins/plugins/aiagentjob/fixtures/fake-opencode-acp.sh
+++ b/src/test/resources/io/jenkins/plugins/aiagentjob/fixtures/fake-opencode-acp.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+test "${1:-}" = "acp"
+printf '%s\n' "$*" > acp-command.txt
+
+IFS= read -r initialize_request
+initialize_id=$(printf '%s\n' "$initialize_request" | sed -n 's/.*"id":\([^,}]*\).*/\1/p')
+printf '{"jsonrpc":"2.0","id":%s,"result":{"protocolVersion":1,"agentCapabilities":{},"authMethods":[]}}\n' "$initialize_id"
+
+IFS= read -r session_request
+session_id=$(printf '%s\n' "$session_request" | sed -n 's/.*"id":\([^,}]*\).*/\1/p')
+printf '{"jsonrpc":"2.0","id":%s,"result":{"sessionId":"session-1","configOptions":[]}}\n' "$session_id"
+
+while IFS= read -r request; do
+  case "$request" in
+    *'"method":"session/set_config_option"'*)
+      printf '%s\n' "$request" >> config-requests.jsonl
+      request_id=$(printf '%s\n' "$request" | sed -n 's/.*"id":\([^,}]*\).*/\1/p')
+      printf '{"jsonrpc":"2.0","id":%s,"result":{"configOptions":[]}}\n' "$request_id"
+      ;;
+    *'"method":"session/prompt"'*)
+      prompt_id=$(printf '%s\n' "$request" | sed -n 's/.*"id":\([^,}]*\).*/\1/p')
+      break
+      ;;
+    *) exit 8 ;;
+  esac
+done
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"available_commands_update","availableCommands":[{"name":"private-test-command","description":"control metadata"}]}}}'
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"tool_call","toolCallId":"call-1","title":"touch approved.txt","kind":"execute","status":"pending","rawInput":{"command":"touch approved.txt"}}}}'
+printf '%s\n' '{"jsonrpc":"2.0","id":"permission-1","method":"session/request_permission","params":{"sessionId":"session-1","toolCall":{"toolCallId":"call-1","title":"touch approved.txt","kind":"execute","status":"pending","rawInput":{"command":"touch approved.txt"}},"options":[{"optionId":"once","name":"Allow once","kind":"allow_once"},{"optionId":"reject","name":"Reject","kind":"reject_once"}]}}'
+
+IFS= read -r approval_response
+printf '%s\n' "$approval_response" > approval-response.json
+case "$approval_response" in
+  *'"outcome":"selected"'*'"optionId":"once"'*) ;;
+  *) exit 9 ;;
+esac
+
+printf '%s\n' '{"jsonrpc":"2.0","id":"fs-1","method":"fs/write_text_file","params":{"sessionId":"session-1","path":"approved.txt","content":"private-test-content"}}'
+IFS= read -r filesystem_response
+case "$filesystem_response" in
+  *'"id":"fs-1"'*'"code":-32601'*) ;;
+  *) exit 10 ;;
+esac
+
+touch approved.txt
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"tool_call_update","toolCallId":"call-1","status":"completed","content":[{"type":"content","content":{"type":"text","text":"created approved.txt"}}],"rawOutput":{"output":"created approved.txt"}}}}'
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"usage_update","used":42,"size":1000,"cost":{"amount":0.01,"currency":"USD"}}}}'
+printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"agent_message_chunk","content":{"type":"text","text":"Created approved.txt"}}}}'
+printf '{"jsonrpc":"2.0","id":%s,"result":{"stopReason":"end_turn"}}\n' "$prompt_id"


### PR DESCRIPTION
## Summary
- route OpenCode manual-approval builds through its bidirectional ACP server
- return Jenkins allow-once or deny decisions over JSON-RPC on local and remote agents
- preserve model, reasoning effort, conversation, and usage handling while filtering ACP control metadata

## Reproduction
1. Configure an OpenCode build with `requireApprovals: true`.
2. Prompt it to create a file.
3. Observe `opencode run` reject the tool before Jenkins can return a decision.

## Verification
- `mvn -B -ntp clean verify`
- remote-agent regression confirms file remains absent before approval and is created after allow-once
- protocol-only smoke against installed `opencode acp --pure`

Closes #24