### PR TITLE
[core] Harden agent execution and log handling

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -15,7 +15,8 @@ permissions:
 
 jobs:
   maven-cd:
-    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@v1
+    if: ${{ inputs.validate_only == true || github.ref == 'refs/heads/main' }}
+    uses: jenkins-infra/github-reusable-workflows/.github/workflows/maven-cd.yml@7704ec4236e99ca271bdef1adb675b65b8e283a9 # v1.8.3
     with:
       validate_only: ${{ inputs.validate_only == true }}
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,20 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: maven
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install browser JavaScript test dependencies
+        run: npm ci
+
       - name: Build and verify
         run: mvn -B clean verify
 
       - name: Test browser JavaScript
-        run: node --test src/test/js/summary_resources.test.js
+        run: npm test
 
       - name: Upload coverage report
         if: matrix.java == 21

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build and verify
         run: mvn -B clean verify
 
+      - name: Test browser JavaScript
+        run: node --test src/test/js/summary_resources.test.js
+
       - name: Upload coverage report
         if: matrix.java == 21
         uses: actions/upload-artifact@v7

--- a/.github/workflows/jenkins-security-scan.yml
+++ b/.github/workflows/jenkins-security-scan.yml
@@ -17,6 +17,6 @@ permissions:
 
 jobs:
   security-scan:
-    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@v2
+    uses: jenkins-infra/jenkins-security-scan/.github/workflows/jenkins-security-scan.yaml@da7438f10fecc21e40174d420ef34daae0874122 # v2.4.0
     with:
       java-cache: 'maven'

--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,8 @@ Thumbs.db
 # Build artifacts
 build-*.log
 
+# Node.js
+node_modules/
+
 # Local agent instructions (not committed)
 AGENTS.local.md

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Build page showing a Cursor Agent conversation with tool calls, markdown-rendere
    - **Reasoning effort** — optional effort override for supported agents (e.g., `high`, `xhigh`).
    - **YOLO mode** — skip confirmation prompts in the agent.
    - **Approvals** — require human approval for tool calls.
-   - **Setup script** — shell commands to run before the agent (install tools, source dotfiles, export secrets).
+   - **Setup script** — shell commands to run before the agent (install tools, source dotfiles, configure runtime variables).
    - **Custom Codex config.toml** — optional, shown only for Codex runs to override settings/MCP per job.
    - **Additional Codex args** — optional, shown only for Codex runs to pass global flags like `--search` or exec flags like `--ephemeral`.
    - **Environment variables** — inject additional env vars (`KEY=VALUE`, one per line).
@@ -84,11 +84,11 @@ aiAgent(
 )
 ```
 
-Gemini with manual tool-call approvals:
+OpenCode with manual tool-call approvals:
 
 ```groovy
 aiAgent(
-  agent: geminiCli(),
+  agent: openCode(),
   prompt: 'Refactor the parser and add tests',
   requireApprovals: true,
   approvalTimeoutSeconds: 300
@@ -106,8 +106,7 @@ aiAgent(
     additionalExecArgs: '--ephemeral --color never'
   ),
   prompt: 'Summarize this project',
-  reasoningEffort: 'xhigh',
-  approvalTimeoutSeconds: 60
+  reasoningEffort: 'xhigh'
 )
 ```
 
@@ -135,7 +134,7 @@ The plugin injects these variables into every build:
 The **Setup script** field accepts shell commands that run before the agent process starts on
 Unix agents.
 Use it to prepare the build environment — install dependencies, source dotfiles, configure PATH,
-or export secrets that the agent needs at runtime.
+or map Jenkins-bound credentials into variables that the agent needs at runtime.
 
 ```bash
 # Example: add local binaries to PATH, source nvm, install a CLI tool
@@ -147,9 +146,10 @@ npm install -g @anthropic-ai/claude-code
 
 The setup script and agent command run in the **same shell session**, so any `export`ed
 variables, PATH changes, or sourced dotfiles are available to the agent. Supports shebang
-lines (e.g. `#!/bin/zsh`) just like the Jenkins Shell build step — if no shebang is present,
-`/bin/sh -xe` is used. If the script exits with a non-zero code the build fails immediately
-without launching the agent. On Windows nodes, use **Command override** instead.
+lines (e.g. `#!/bin/zsh`) — if no shebang is present, `/bin/sh -e` is used. If the script exits
+with a non-zero code the build fails immediately without launching the agent. Shell tracing is
+disabled for setup and generated agent commands so expanded values, prompts, and arguments are not
+written to the build log. On Windows nodes, use **Command override** instead.
 
 ### Command Override
 
@@ -194,11 +194,9 @@ Prompt and command-line values are not retained in build action metadata because
 
 ### Approval Gates
 
-When approvals are enabled and YOLO mode is off, tool calls detected in the agent's output trigger a blocking approval request. The build pauses until a user approves or denies from the build page. Denied or timed-out requests fail the build.
+Manual approvals are currently supported only for OpenCode. Approval builds use its bidirectional Agent Client Protocol server and pause before tool execution until a user approves or denies from the build page. Denied or timed-out requests fail the build. The installed OpenCode CLI must support `opencode acp`; builds without manual approvals continue to use `opencode run`.
 
-OpenCode approval builds use its bidirectional Agent Client Protocol server. The installed OpenCode CLI must support `opencode acp`. OpenCode builds without manual approvals continue to use `opencode run`.
-
-Codex CLI does not expose a non-interactive approval channel, so Codex jobs reject manual approvals instead of silently running with `--ask-for-approval never`.
+Claude Code, Codex CLI, Cursor Agent, Gemini CLI, and command overrides do not expose a supported bidirectional approval channel to this plugin. Jobs reject those combinations before launching instead of showing an approval that cannot affect tool execution.
 
 ### Usage Statistics
 

--- a/README.md
+++ b/README.md
@@ -188,13 +188,17 @@ Gemini CLI and Cursor Agent currently ignore the field in the built-in command t
 
 ### Credential Injection
 
-If the selected agent type has an associated credential ID (e.g., API key), the plugin resolves it from Jenkins credentials and injects it as an environment variable. The credential is masked in the build log.
+If the selected agent type has an associated credential ID (e.g., API key), the plugin resolves it from Jenkins credentials and injects it as an environment variable. The credential is masked in the build log and captured raw agent log.
+
+Prompt and command-line values are not retained in build action metadata because Pipeline and environment expansion may place credentials in either value.
 
 ### Approval Gates
 
 When approvals are enabled and YOLO mode is off, tool calls detected in the agent's output trigger a blocking approval request. The build pauses until a user approves or denies from the build page. Denied or timed-out requests fail the build.
 
 OpenCode approval builds use its bidirectional Agent Client Protocol server. The installed OpenCode CLI must support `opencode acp`. OpenCode builds without manual approvals continue to use `opencode run`.
+
+Codex CLI does not expose a non-interactive approval channel, so Codex jobs reject manual approvals instead of silently running with `--ask-for-approval never`.
 
 ### Usage Statistics
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,314 @@
+{
+  "name": "ai-agent-plugin-browser-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ai-agent-plugin-browser-tests",
+      "devDependencies": {
+        "linkedom": "0.18.13"
+      }
+    },
+    "node_modules/boolbase": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
+      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
+      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0",
+        "css-what": "^8.0.0",
+        "domhandler": "^6.0.1",
+        "domutils": "^4.0.2",
+        "nth-check": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
+      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.13",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.13.tgz",
+      "integrity": "sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^7.0.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.1.0",
+        "uhyphen": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "canvas": ">= 2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
+      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "ai-agent-plugin-browser-tests",
+  "private": true,
+  "scripts": {
+    "test": "node --check src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary_resources.js && node --test src/test/js/summary_resources.test.js"
+  },
+  "devDependencies": {
+    "linkedom": "0.18.13"
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>plain-credentials</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>credentials-binding</artifactId>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AcpClientSession.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AcpClientSession.java
@@ -207,6 +207,10 @@ final class AcpClientSession {
             summary = LogFormatUtils.firstNonEmpty(toolCall, "title");
         }
 
+        toolCallId = outputHandler.maskSensitiveValues(toolCallId);
+        toolName = outputHandler.maskSensitiveValues(toolName);
+        summary = outputHandler.maskSensitiveValues(summary);
+
         ExecutionRegistry.PendingApproval pending =
                 liveExecution.createPendingApproval(toolCallId, toolName, summary);
         outputHandler.writeStatus(
@@ -218,6 +222,10 @@ final class AcpClientSession {
 
         ExecutionRegistry.ApprovalDecision decision =
                 liveExecution.awaitDecision(pending, approvalTimeout);
+        if (!proc.isAlive()) {
+            outputHandler.writeStatus("Approval denied: " + decision.getReason());
+            throw new ApprovalDeniedException();
+        }
         JSONArray options = params.optJSONArray("options");
         String optionId =
                 findPermissionOption(

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AgentUsageStats.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AgentUsageStats.java
@@ -55,7 +55,9 @@ public final class AgentUsageStats implements Serializable {
 
     public long getTotalTokens() {
         if (totalTokens > 0) return totalTokens;
-        return inputTokens + outputTokens + cacheReadTokens + cacheWriteTokens;
+        return saturatedAdd(
+                saturatedAdd(inputTokens, outputTokens),
+                saturatedAdd(cacheReadTokens, cacheWriteTokens));
     }
 
     public long getReasoningTokens() {
@@ -174,32 +176,39 @@ public final class AgentUsageStats implements Serializable {
 
     /** Increment input tokens (additive, for multi-step agents like OpenCode). */
     public void incrementInputTokens(long value) {
-        inputTokens += value;
+        inputTokens = saturatedAdd(inputTokens, value);
     }
 
     /** Increment output tokens (additive). */
     public void incrementOutputTokens(long value) {
-        outputTokens += value;
+        outputTokens = saturatedAdd(outputTokens, value);
     }
 
     /** Increment reasoning tokens (additive). */
     public void incrementReasoningTokens(long value) {
-        reasoningTokens += value;
+        reasoningTokens = saturatedAdd(reasoningTokens, value);
     }
 
     /** Increment total tokens (additive). */
     public void incrementTotalTokens(long value) {
-        totalTokens += value;
+        totalTokens = saturatedAdd(totalTokens, value);
     }
 
     /** Increment cache read tokens (additive). */
     public void incrementCacheReadTokens(long value) {
-        cacheReadTokens += value;
+        cacheReadTokens = saturatedAdd(cacheReadTokens, value);
     }
 
     /** Increment cache write tokens (additive). */
     public void incrementCacheWriteTokens(long value) {
-        cacheWriteTokens += value;
+        cacheWriteTokens = saturatedAdd(cacheWriteTokens, value);
+    }
+
+    /** Adds non-negative token counts without wrapping on malformed or oversized input. */
+    public static long saturatedAdd(long current, long value) {
+        long safeCurrent = Math.max(0, current);
+        if (value <= 0) return safeCurrent;
+        return safeCurrent > Long.MAX_VALUE - value ? Long.MAX_VALUE : safeCurrent + value;
     }
 
     /** Increment cost (additive). */

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactory.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactory.java
@@ -8,10 +8,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * Builds the CLI command line for the selected agent handler. Also handles environment variable
- * parsing and command-to-string serialisation.
- */
+/** Builds the CLI command line for the selected agent handler and parses environment variables. */
 final class AiAgentCommandFactory {
     private AiAgentCommandFactory() {}
 
@@ -20,6 +17,7 @@ final class AiAgentCommandFactory {
         if (handler == null) {
             throw new IllegalStateException("No agent handler configured.");
         }
+        handler.validateExecution(config);
         List<String> command = new ArrayList<>(handler.buildDefaultCommand(config, prompt));
 
         String extraArgs = Util.fixEmptyAndTrim(config.getExtraArgs());
@@ -52,21 +50,5 @@ final class AiAgentCommandFactory {
             }
         }
         return values;
-    }
-
-    static String commandAsString(List<String> command) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < command.size(); i++) {
-            if (i > 0) {
-                sb.append(' ');
-            }
-            String token = command.get(i);
-            if (token.contains(" ") || token.contains("\"")) {
-                sb.append('"').append(token.replace("\"", "\\\"")).append('"');
-            } else {
-                sb.append(token);
-            }
-        }
-        return sb.toString();
     }
 }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutionCustomization.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutionCustomization.java
@@ -38,13 +38,21 @@ public final class AiAgentExecutionCustomization {
     }
 
     public void cleanup(TaskListener listener) {
+        boolean interrupted = false;
         for (CleanupAction cleanupAction : cleanupActions) {
             try {
                 cleanupAction.run();
-            } catch (IOException | InterruptedException e) {
+            } catch (InterruptedException e) {
+                interrupted = true;
+                listener.getLogger()
+                        .println("[ai-agent] Warning: cleanup failed: " + e.getMessage());
+            } catch (IOException e) {
                 listener.getLogger()
                         .println("[ai-agent] Warning: cleanup failed: " + e.getMessage());
             }
+        }
+        if (interrupted) {
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -11,8 +11,10 @@ import hudson.Util;
 import hudson.console.LineTransformationOutputStream;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+import hudson.util.ArgumentListBuilder;
 import hudson.util.StreamCopyThread;
 
+import org.jenkinsci.plugins.credentialsbinding.masking.SecretPatterns;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
 import java.io.BufferedWriter;
@@ -32,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Pattern;
 
 /**
  * Runs the AI agent subprocess, wires stdout/stderr to the Jenkins build log and the raw JSONL log
@@ -55,6 +58,8 @@ final class AiAgentExecutor {
         String model = Util.replaceMacro(Util.fixNull(config.getModel()), env);
         String workDirValue = Util.replaceMacro(Util.fixNull(config.getWorkingDirectory()), env);
         String commandOverride = Util.fixNull(config.getCommandOverride()).trim();
+        AiAgentTypeHandler agent = config.getAgent();
+        agent.validateExecution(config);
 
         FilePath runDirectory = resolveRunDirectory(workspace, workDirValue);
         runDirectory.mkdirs();
@@ -64,6 +69,7 @@ final class AiAgentExecutor {
                 new LinkedHashMap<>(
                         AiAgentCommandFactory.parseEnvironmentVariables(
                                 config.getEnvironmentVariables())));
+        List<String> sensitiveValues = new ArrayList<>();
 
         // Inject API key from Jenkins Credentials if configured
         String credentialsId = Util.fixEmptyAndTrim(config.getApiCredentialsId());
@@ -76,7 +82,11 @@ final class AiAgentExecutor {
                             Collections.<DomainRequirement>emptyList());
             if (cred != null) {
                 String envVarName = config.getEffectiveApiKeyEnvVar();
-                procEnv.put(envVarName, cred.getSecret().getPlainText());
+                String secretValue = cred.getSecret().getPlainText();
+                procEnv.put(envVarName, secretValue);
+                if (!secretValue.isEmpty()) {
+                    sensitiveValues.add(secretValue);
+                }
                 listener.getLogger()
                         .println(
                                 "[ai-agent] API key injected as "
@@ -104,150 +114,166 @@ final class AiAgentExecutor {
                             + "Use Command override for Windows nodes.");
         }
         AiAgentExecutionCustomization executionCustomization =
-                config.getAgent().prepareExecution(config, workspace, listener);
-        procEnv.putAll(executionCustomization.getEnvironment());
-
-        AiAgentTypeHandler.AcpExecutionSpec acpExecution =
-                commandOverride.isEmpty() && config.isRequireApprovals() && !config.isYoloMode()
-                        ? config.getAgent().buildAcpExecution(config)
-                        : null;
-
-        List<String> agentCommand;
-        if (!commandOverride.isEmpty()) {
-            agentCommand = List.of(commandOverride);
-        } else if (acpExecution != null) {
-            agentCommand = acpExecution.getCommand();
-        } else {
-            agentCommand = AiAgentCommandFactory.buildDefaultCommand(config, prompt);
-        }
-
-        boolean needsShellEnvironmentBootstrap =
-                launcher.isUnix() && !executionCustomization.getEnvironment().isEmpty();
-        boolean disableInteractive = config.isDisableInteractive() && acpExecution == null;
-        boolean forceUnixShell = disableInteractive && launcher.isUnix();
-        List<String> command;
+                agent.prepareExecution(config, workspace, listener);
         FilePath tempSetupScript = null;
-        if ((!setupScript.isEmpty() && launcher.isUnix())
-                || needsShellEnvironmentBootstrap
-                || forceUnixShell) {
-            String combinedScript =
-                    buildCombinedScript(
-                            setupScript,
-                            executionCustomization.getEnvironment(),
-                            agentCommand,
-                            commandOverride,
-                            disableInteractive);
-            tempSetupScript = writeTempScript(workspace, combinedScript);
-            command = buildShellCommand(combinedScript, tempSetupScript);
-        } else if (!commandOverride.isEmpty()) {
-            if (launcher.isUnix()) {
-                // Use a non-login shell so injected HOME/USERPROFILE are not overridden.
-                command = List.of("/bin/sh", "-c", commandOverride);
-            } else {
-                String cmd = commandOverride;
-                if (disableInteractive && !cmd.toUpperCase().contains("< NUL")) {
-                    cmd =
-                            cmd.endsWith("\n")
-                                    ? cmd.substring(0, cmd.length() - 1) + " < NUL\n"
-                                    : cmd + " < NUL";
-                }
-                command = List.of("cmd", "/c", cmd);
-            }
-        } else if (disableInteractive) {
-            command =
-                    List.of(
-                            "cmd",
-                            "/c",
-                            AiAgentCommandFactory.commandAsString(agentCommand) + " < NUL");
-        } else {
-            command = agentCommand;
-        }
-
-        if (!setupScript.isEmpty()) {
-            listener.getLogger().println("[ai-agent] Setup script will run before the agent.");
-        }
-
-        String commandLine =
-                commandOverride.isEmpty()
-                        ? AiAgentCommandFactory.commandAsString(agentCommand)
-                        : commandOverride;
-        int invocationId =
-                action.markStarted(
-                        config.getAgent().getDescriptor().getDisplayName(),
-                        prompt,
-                        model,
-                        commandLine,
-                        config.isYoloMode(),
-                        config.isRequireApprovals());
-
-        File rawLogFile = action.getRawLogFile(invocationId);
-        Files.deleteIfExists(rawLogFile.toPath());
-
-        ExecutionRegistry.LiveExecution liveExecution =
-                ExecutionRegistry.register(run, invocationId);
-        Duration approvalTimeout =
-                Duration.ofSeconds(Math.max(1, config.getApprovalTimeoutSeconds()));
-
-        AgentOutputHandler outputHandler =
-                new AgentOutputHandler(
-                        listener.getLogger(),
-                        rawLogFile,
-                        liveExecution,
-                        config.isRequireApprovals() && !config.isYoloMode() && acpExecution == null,
-                        approvalTimeout,
-                        config.getAgent().getLogFormat());
-        OutputStream stdoutSink = new NonClosingSynchronizedOutputStream(outputHandler);
-        OutputStream stderrSink = new NonClosingSynchronizedOutputStream(outputHandler);
-
-        int exitCode;
         try {
-            if (acpExecution != null) {
-                exitCode =
-                        executeAcpProcess(
-                                launcher,
-                                command,
-                                runDirectory,
-                                procEnv,
-                                listener,
-                                outputHandler,
-                                liveExecution,
-                                approvalTimeout,
-                                prompt,
-                                acpExecution);
+            procEnv.putAll(executionCustomization.getEnvironment());
+
+            AiAgentTypeHandler.AcpExecutionSpec acpExecution =
+                    commandOverride.isEmpty() && config.isRequireApprovals() && !config.isYoloMode()
+                            ? agent.buildAcpExecution(config)
+                            : null;
+
+            List<String> agentCommand;
+            if (!commandOverride.isEmpty()) {
+                agentCommand = List.of(commandOverride);
+            } else if (acpExecution != null) {
+                agentCommand = acpExecution.getCommand();
             } else {
-                Proc proc =
-                        launcher.launch()
-                                .cmds(command)
-                                .pwd(runDirectory)
-                                .envs(procEnv)
-                                .stdout(stdoutSink)
-                                .stderr(stderrSink)
-                                .quiet(true)
-                                .start();
-                outputHandler.attach(proc);
-                exitCode = proc.join();
+                agentCommand = AiAgentCommandFactory.buildDefaultCommand(config, prompt);
             }
-        } finally {
-            outputHandler.close();
-            ExecutionRegistry.unregister(run, invocationId);
-            if (tempSetupScript != null) {
+
+            boolean needsShellEnvironmentBootstrap =
+                    launcher.isUnix() && !executionCustomization.getEnvironment().isEmpty();
+            boolean disableInteractive = config.isDisableInteractive() && acpExecution == null;
+            List<String> command;
+            if ((!setupScript.isEmpty() && launcher.isUnix()) || needsShellEnvironmentBootstrap) {
+                String combinedScript =
+                        buildCombinedScript(
+                                setupScript,
+                                executionCustomization.getEnvironment(),
+                                agentCommand,
+                                commandOverride);
+                tempSetupScript = writeTempScript(workspace, combinedScript);
+                command = buildShellCommand(combinedScript, tempSetupScript);
+            } else if (!commandOverride.isEmpty()) {
+                if (launcher.isUnix()) {
+                    // Use a non-login shell so injected HOME/USERPROFILE are not overridden.
+                    command = List.of("/bin/sh", "-c", commandOverride);
+                } else {
+                    command = List.of("cmd", "/c", commandOverride);
+                }
+            } else if (!launcher.isUnix()) {
+                command = buildWindowsCommand(agentCommand);
+            } else {
+                command = agentCommand;
+            }
+
+            if (!setupScript.isEmpty()) {
+                listener.getLogger().println("[ai-agent] Setup script will run before the agent.");
+            }
+
+            int invocationId =
+                    action.markStarted(
+                            agent.getDescriptor().getDisplayName(),
+                            "",
+                            model,
+                            "",
+                            config.isYoloMode(),
+                            config.isRequireApprovals());
+
+            AgentOutputHandler outputHandler = null;
+            boolean registered = false;
+            int exitCode;
+            try {
+                File rawLogFile = action.getRawLogFile(invocationId);
+                Files.deleteIfExists(rawLogFile.toPath());
+
+                ExecutionRegistry.LiveExecution liveExecution =
+                        ExecutionRegistry.register(run, invocationId);
+                registered = true;
+                Duration approvalTimeout =
+                        Duration.ofSeconds(Math.max(1, config.getApprovalTimeoutSeconds()));
+
+                outputHandler =
+                        new AgentOutputHandler(
+                                listener.getLogger(),
+                                rawLogFile,
+                                liveExecution,
+                                config.isRequireApprovals()
+                                        && !config.isYoloMode()
+                                        && acpExecution == null,
+                                approvalTimeout,
+                                agent.getLogFormat(),
+                                sensitiveValues);
+                OutputStream stdoutSink = new NonClosingSynchronizedOutputStream(outputHandler);
+                OutputStream stderrSink = new NonClosingSynchronizedOutputStream(outputHandler);
+
+                if (acpExecution != null) {
+                    exitCode =
+                            executeAcpProcess(
+                                    launcher,
+                                    command,
+                                    runDirectory,
+                                    procEnv,
+                                    listener,
+                                    outputHandler,
+                                    liveExecution,
+                                    approvalTimeout,
+                                    prompt,
+                                    acpExecution);
+                } else {
+                    Launcher.ProcStarter procStarter =
+                            launcher.launch()
+                                    .cmds(command)
+                                    .pwd(runDirectory)
+                                    .envs(procEnv)
+                                    .stdout(stdoutSink)
+                                    .stderr(stderrSink)
+                                    .quiet(true);
+                    if (disableInteractive) {
+                        procStarter.stdin(InputStream.nullInputStream());
+                    }
+                    Proc proc = procStarter.start();
+                    outputHandler.attach(proc);
+                    try {
+                        exitCode = proc.join();
+                        outputHandler.awaitTermination();
+                    } catch (IOException | InterruptedException e) {
+                        outputHandler.requestTermination();
+                        try {
+                            outputHandler.awaitTermination();
+                        } catch (IOException | InterruptedException terminationFailure) {
+                            if (terminationFailure != e) {
+                                e.addSuppressed(terminationFailure);
+                            }
+                        }
+                        throw e;
+                    }
+                }
+            } finally {
                 try {
-                    tempSetupScript.delete();
-                } catch (IOException e) {
-                    listener.getLogger()
-                            .println(
-                                    "[ai-agent] Warning: could not delete temp script: "
-                                            + e.getMessage());
+                    if (outputHandler != null) {
+                        outputHandler.close();
+                    }
+                } finally {
+                    if (registered) {
+                        ExecutionRegistry.unregister(run, invocationId);
+                    }
                 }
             }
-            executionCustomization.cleanup(listener);
-        }
 
-        if (outputHandler.wasDeniedByApproval()) {
-            exitCode = 1;
+            if (outputHandler.wasDeniedByApproval()) {
+                exitCode = 1;
+            }
+            action.markCompleted(invocationId, exitCode);
+            return exitCode;
+        } finally {
+            try {
+                if (tempSetupScript != null) {
+                    try {
+                        tempSetupScript.delete();
+                    } catch (IOException e) {
+                        listener.getLogger()
+                                .println(
+                                        "[ai-agent] Warning: could not delete temp script: "
+                                                + e.getMessage());
+                    }
+                }
+            } finally {
+                executionCustomization.cleanup(listener);
+            }
         }
-        action.markCompleted(invocationId, exitCode);
-        return exitCode;
     }
 
     private static int executeAcpProcess(
@@ -317,18 +343,11 @@ final class AiAgentExecutor {
             String setupScript,
             Map<String, String> shellEnvironment,
             List<String> agentCommand,
-            String commandOverride,
-            boolean disableInteractive) {
+            String commandOverride) {
         StringBuilder sb = new StringBuilder();
         appendShebangAwarePreamble(sb, setupScript, shellEnvironment);
         if (!commandOverride.isEmpty()) {
             String cmd = commandOverride;
-            if (disableInteractive && !cmd.contains("< /dev/null")) {
-                cmd =
-                        cmd.endsWith("\n")
-                                ? cmd.substring(0, cmd.length() - 1) + " < /dev/null\n"
-                                : cmd + " < /dev/null";
-            }
             sb.append(cmd);
             if (!cmd.endsWith("\n")) {
                 sb.append('\n');
@@ -337,9 +356,6 @@ final class AiAgentExecutor {
             sb.append("exec");
             for (String token : agentCommand) {
                 sb.append(' ').append(shellQuote(token));
-            }
-            if (disableInteractive) {
-                sb.append(" < /dev/null");
             }
             sb.append('\n');
         }
@@ -425,6 +441,10 @@ final class AiAgentExecutor {
         return "'" + s.replace("'", "'\\''") + "'";
     }
 
+    static List<String> buildWindowsCommand(List<String> command) {
+        return new ArgumentListBuilder().add(command).toWindowsCommand().toList();
+    }
+
     private static FilePath resolveRunDirectory(FilePath workspace, String workDirValue) {
         String trimmed = Util.fixNull(workDirValue).trim();
         if (trimmed.isEmpty()) {
@@ -476,8 +496,14 @@ final class AiAgentExecutor {
         private final boolean approvalsEnabled;
         private final Duration approvalTimeout;
         private final AiAgentLogFormat logFormat;
+        private final Pattern sensitivePattern;
+        private final AiAgentLogParser.ParseState parseState = new AiAgentLogParser.ParseState();
         private final AtomicLong lineCounter = new AtomicLong();
+        private final Object terminationLock = new Object();
         private volatile Proc proc;
+        private volatile boolean terminationRequested;
+        private volatile Thread terminationThread;
+        private volatile IOException terminationFailure;
         private volatile boolean deniedByApproval;
 
         AgentOutputHandler(
@@ -486,7 +512,8 @@ final class AiAgentExecutor {
                 ExecutionRegistry.LiveExecution liveExecution,
                 boolean approvalsEnabled,
                 Duration approvalTimeout,
-                AiAgentLogFormat logFormat)
+                AiAgentLogFormat logFormat,
+                List<String> sensitiveValues)
                 throws IOException {
             this.logger = logger;
             this.rawWriter =
@@ -498,10 +525,65 @@ final class AiAgentExecutor {
             this.approvalsEnabled = approvalsEnabled;
             this.approvalTimeout = approvalTimeout;
             this.logFormat = logFormat;
+            this.sensitivePattern =
+                    SecretPatterns.getAggregateSecretPattern(
+                            expandSensitiveValues(sensitiveValues));
         }
 
         void attach(Proc proc) {
-            this.proc = proc;
+            synchronized (terminationLock) {
+                this.proc = proc;
+                startTerminationLocked();
+            }
+        }
+
+        void requestTermination() {
+            liveExecution.cancelPendingApprovals("agent process terminated");
+            synchronized (terminationLock) {
+                terminationRequested = true;
+                startTerminationLocked();
+            }
+        }
+
+        void awaitTermination() throws IOException, InterruptedException {
+            Thread thread;
+            synchronized (terminationLock) {
+                thread = terminationThread;
+            }
+            if (thread == null) {
+                return;
+            }
+            thread.join();
+            IOException failure = terminationFailure;
+            if (failure != null) {
+                throw failure;
+            }
+        }
+
+        private void startTerminationLocked() {
+            if (!terminationRequested || proc == null || terminationThread != null) {
+                return;
+            }
+            Proc processToKill = proc;
+            Thread thread =
+                    new Thread(
+                            () -> {
+                                try {
+                                    processToKill.kill();
+                                } catch (IOException e) {
+                                    terminationFailure = e;
+                                } catch (InterruptedException e) {
+                                    Thread.currentThread().interrupt();
+                                    terminationFailure =
+                                            new IOException(
+                                                    "Interrupted while terminating agent process.",
+                                                    e);
+                                }
+                            },
+                            "ai-agent-process-terminator");
+            thread.setDaemon(true);
+            terminationThread = thread;
+            thread.start();
         }
 
         boolean wasDeniedByApproval() {
@@ -515,7 +597,7 @@ final class AiAgentExecutor {
         }
 
         synchronized void recordLine(String rawLine) throws IOException {
-            String line = rawLine;
+            String line = maskSensitiveValues(rawLine);
             if (line.endsWith("\r")) {
                 line = line.substring(0, line.length() - 1);
             }
@@ -533,40 +615,63 @@ final class AiAgentExecutor {
             }
 
             long id = lineCounter.incrementAndGet();
-            AiAgentLogParser.ParsedLine parsedLine =
-                    AiAgentLogParser.parseLine(id, line, logFormat);
-            if (!parsedLine.isToolCall()) {
-                return;
-            }
-
-            ExecutionRegistry.PendingApproval pending =
-                    liveExecution.createPendingApproval(
-                            parsedLine.getToolCallIdOrGenerated(),
-                            parsedLine.getToolName(),
-                            parsedLine.getSummary());
-            writeStatus(
-                    "Approval required: "
-                            + pending.getToolName()
-                            + " ("
-                            + pending.getToolCallId()
-                            + ")");
-
-            ExecutionRegistry.ApprovalDecision decision =
-                    liveExecution.awaitDecision(pending, approvalTimeout);
-            if (!decision.isApproved()) {
-                deniedByApproval = true;
-                writeStatus("Approval denied: " + decision.getReason());
-                Proc currentProc = this.proc;
-                if (currentProc != null) {
-                    try {
-                        currentProc.kill();
-                    } catch (InterruptedException e) {
-                        Thread.currentThread().interrupt();
-                    }
+            for (AiAgentLogParser.ParsedLine parsedLine :
+                    AiAgentLogParser.parseLines(id, line, logFormat)) {
+                if (!parseState.shouldEmit(parsedLine)) {
+                    continue;
                 }
-            } else {
+                if (!parsedLine.isToolCall()) {
+                    continue;
+                }
+
+                ExecutionRegistry.PendingApproval pending =
+                        liveExecution.createPendingApproval(
+                                parsedLine.getToolCallIdOrGenerated(),
+                                parsedLine.getToolName(),
+                                parsedLine.getSummary());
+                writeStatus(
+                        "Approval required: "
+                                + pending.getToolName()
+                                + " ("
+                                + pending.getToolCallId()
+                                + ")");
+
+                ExecutionRegistry.ApprovalDecision decision =
+                        liveExecution.awaitDecision(pending, approvalTimeout);
+                if (!decision.isApproved()) {
+                    deniedByApproval = true;
+                    try {
+                        writeStatus("Approval denied: " + decision.getReason());
+                    } finally {
+                        requestTermination();
+                    }
+                    return;
+                }
                 writeStatus("Approval granted: " + pending.getToolName());
             }
+        }
+
+        private String maskSensitiveValues(String value) {
+            if (sensitivePattern.pattern().isEmpty()) {
+                return value;
+            }
+            return sensitivePattern.matcher(value).replaceAll("****");
+        }
+
+        private static List<String> expandSensitiveValues(List<String> sensitiveValues) {
+            List<String> expanded = new ArrayList<>();
+            for (String sensitiveValue : sensitiveValues) {
+                if (sensitiveValue == null || sensitiveValue.isEmpty()) {
+                    continue;
+                }
+                expanded.add(sensitiveValue);
+                for (String line : sensitiveValue.split("\\R")) {
+                    if (!line.isEmpty()) {
+                        expanded.add(line);
+                    }
+                }
+            }
+            return expanded;
         }
 
         synchronized void writeStatus(String message) throws IOException {

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -329,6 +329,7 @@ final class AiAgentExecutor {
                         new NonClosingSynchronizedOutputStream(outputHandler),
                         false);
         stderrThread.start();
+        Thread processMonitor = startAcpProcessMonitor(proc, liveExecution);
         try {
             AcpClientSession session =
                     new AcpClientSession(
@@ -348,9 +349,32 @@ final class AiAgentExecutor {
                     proc.kill();
                 }
                 proc.joinWithTimeout(10, TimeUnit.SECONDS, listener);
+                processMonitor.join(TimeUnit.SECONDS.toMillis(10));
                 stderrThread.join(TimeUnit.SECONDS.toMillis(10));
             }
         }
+    }
+
+    private static Thread startAcpProcessMonitor(
+            Proc proc, ExecutionRegistry.LiveExecution liveExecution) {
+        Thread thread =
+                new Thread(
+                        () -> {
+                            String reason = "agent process exited while waiting for approval";
+                            try {
+                                proc.join();
+                            } catch (IOException e) {
+                                reason = "agent process monitor failed: " + e.getMessage();
+                            } catch (InterruptedException e) {
+                                Thread.currentThread().interrupt();
+                                reason = "agent process monitor was interrupted";
+                            }
+                            liveExecution.cancelPendingApprovals(reason);
+                        },
+                        "ai-agent-acp-process-monitor");
+        thread.setDaemon(true);
+        thread.start();
+        return thread;
     }
 
     private static String buildCombinedScript(
@@ -459,7 +483,7 @@ final class AiAgentExecutor {
     }
 
     static List<String> buildWindowsCommand(List<String> command) {
-        return new ArgumentListBuilder().add(command).toWindowsCommand().toList();
+        return new ArgumentListBuilder().add(command).toWindowsCommand(true).toList();
     }
 
     private static FilePath resolveRunDirectory(FilePath workspace, String workDirValue) {
@@ -705,7 +729,7 @@ final class AiAgentExecutor {
             rawWriter.flush();
         }
 
-        private String maskSensitiveValues(String value) {
+        String maskSensitiveValues(String value) {
             if (sensitivePattern.pattern().isEmpty()) {
                 return value;
             }
@@ -737,7 +761,8 @@ final class AiAgentExecutor {
         }
 
         synchronized void writeStatus(String message) throws IOException {
-            logger.write(("[ai-agent] " + message + "\n").getBytes(StandardCharsets.UTF_8));
+            String safeMessage = maskSensitiveValues(message);
+            logger.write(("[ai-agent] " + safeMessage + "\n").getBytes(StandardCharsets.UTF_8));
             logger.flush();
         }
 

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -14,6 +14,8 @@ import hudson.model.TaskListener;
 import hudson.util.ArgumentListBuilder;
 import hudson.util.StreamCopyThread;
 
+import net.sf.json.util.JSONUtils;
+
 import org.jenkinsci.plugins.credentialsbinding.masking.SecretPatterns;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 
@@ -33,7 +35,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.regex.Pattern;
 
 /**
@@ -56,10 +57,21 @@ final class AiAgentExecutor {
 
         String prompt = Util.replaceMacro(Util.fixNull(config.getPrompt()), env);
         String model = Util.replaceMacro(Util.fixNull(config.getModel()), env);
+        String reasoningEffort = Util.replaceMacro(Util.fixNull(config.getReasoningEffort()), env);
         String workDirValue = Util.replaceMacro(Util.fixNull(config.getWorkingDirectory()), env);
         String commandOverride = Util.fixNull(config.getCommandOverride()).trim();
-        AiAgentTypeHandler agent = config.getAgent();
-        agent.validateExecution(config);
+        AiAgentConfiguration resolvedConfig =
+                new ResolvedAiAgentConfiguration(config, model, reasoningEffort);
+        AiAgentTypeHandler agent = resolvedConfig.getAgent();
+        agent.validateExecution(resolvedConfig);
+        boolean manualApprovals =
+                resolvedConfig.isRequireApprovals() && !resolvedConfig.isYoloMode();
+        AiAgentTypeHandler.AcpExecutionSpec acpExecution =
+                manualApprovals ? agent.buildAcpExecution(resolvedConfig) : null;
+        if (manualApprovals && acpExecution == null) {
+            throw new IllegalArgumentException(
+                    "Manual approvals require an ACP-capable agent command.");
+        }
 
         FilePath runDirectory = resolveRunDirectory(workspace, workDirValue);
         runDirectory.mkdirs();
@@ -68,11 +80,11 @@ final class AiAgentExecutor {
         procEnv.putAll(
                 new LinkedHashMap<>(
                         AiAgentCommandFactory.parseEnvironmentVariables(
-                                config.getEnvironmentVariables())));
+                                resolvedConfig.getEnvironmentVariables())));
         List<String> sensitiveValues = new ArrayList<>();
 
         // Inject API key from Jenkins Credentials if configured
-        String credentialsId = Util.fixEmptyAndTrim(config.getApiCredentialsId());
+        String credentialsId = Util.fixEmptyAndTrim(resolvedConfig.getApiCredentialsId());
         if (credentialsId != null) {
             StringCredentials cred =
                     CredentialsProvider.findCredentialById(
@@ -81,7 +93,7 @@ final class AiAgentExecutor {
                             run,
                             Collections.<DomainRequirement>emptyList());
             if (cred != null) {
-                String envVarName = config.getEffectiveApiKeyEnvVar();
+                String envVarName = resolvedConfig.getEffectiveApiKeyEnvVar();
                 String secretValue = cred.getSecret().getPlainText();
                 procEnv.put(envVarName, secretValue);
                 if (!secretValue.isEmpty()) {
@@ -105,24 +117,19 @@ final class AiAgentExecutor {
 
         procEnv.put("AI_AGENT_PROMPT", prompt);
         procEnv.put("AI_AGENT_MODEL", model);
-        procEnv.put("AI_AGENT_REASONING_EFFORT", Util.fixNull(config.getReasoningEffort()));
+        procEnv.put("AI_AGENT_REASONING_EFFORT", reasoningEffort);
 
-        String setupScript = Util.fixNull(config.getSetupScript()).trim();
+        String setupScript = Util.fixNull(resolvedConfig.getSetupScript()).trim();
         if (!setupScript.isEmpty() && !launcher.isUnix()) {
             throw new IOException(
                     "Setup script is currently supported only on Unix agents. "
                             + "Use Command override for Windows nodes.");
         }
         AiAgentExecutionCustomization executionCustomization =
-                agent.prepareExecution(config, workspace, listener);
+                agent.prepareExecution(resolvedConfig, workspace, listener);
         FilePath tempSetupScript = null;
         try {
             procEnv.putAll(executionCustomization.getEnvironment());
-
-            AiAgentTypeHandler.AcpExecutionSpec acpExecution =
-                    commandOverride.isEmpty() && config.isRequireApprovals() && !config.isYoloMode()
-                            ? agent.buildAcpExecution(config)
-                            : null;
 
             List<String> agentCommand;
             if (!commandOverride.isEmpty()) {
@@ -130,12 +137,13 @@ final class AiAgentExecutor {
             } else if (acpExecution != null) {
                 agentCommand = acpExecution.getCommand();
             } else {
-                agentCommand = AiAgentCommandFactory.buildDefaultCommand(config, prompt);
+                agentCommand = AiAgentCommandFactory.buildDefaultCommand(resolvedConfig, prompt);
             }
 
             boolean needsShellEnvironmentBootstrap =
                     launcher.isUnix() && !executionCustomization.getEnvironment().isEmpty();
-            boolean disableInteractive = config.isDisableInteractive() && acpExecution == null;
+            boolean disableInteractive =
+                    resolvedConfig.isDisableInteractive() && acpExecution == null;
             List<String> command;
             if ((!setupScript.isEmpty() && launcher.isUnix()) || needsShellEnvironmentBootstrap) {
                 String combinedScript =
@@ -169,95 +177,101 @@ final class AiAgentExecutor {
                             "",
                             model,
                             "",
-                            config.isYoloMode(),
-                            config.isRequireApprovals());
+                            resolvedConfig.isYoloMode(),
+                            manualApprovals);
 
-            AgentOutputHandler outputHandler = null;
-            boolean registered = false;
-            int exitCode;
+            int exitCode = -1;
+            Throwable executionFailure = null;
             try {
-                File rawLogFile = action.getRawLogFile(invocationId);
-                Files.deleteIfExists(rawLogFile.toPath());
-
-                ExecutionRegistry.LiveExecution liveExecution =
-                        ExecutionRegistry.register(run, invocationId);
-                registered = true;
-                Duration approvalTimeout =
-                        Duration.ofSeconds(Math.max(1, config.getApprovalTimeoutSeconds()));
-
-                outputHandler =
-                        new AgentOutputHandler(
-                                listener.getLogger(),
-                                rawLogFile,
-                                liveExecution,
-                                config.isRequireApprovals()
-                                        && !config.isYoloMode()
-                                        && acpExecution == null,
-                                approvalTimeout,
-                                agent.getLogFormat(),
-                                sensitiveValues);
-                OutputStream stdoutSink = new NonClosingSynchronizedOutputStream(outputHandler);
-                OutputStream stderrSink = new NonClosingSynchronizedOutputStream(outputHandler);
-
-                if (acpExecution != null) {
-                    exitCode =
-                            executeAcpProcess(
-                                    launcher,
-                                    command,
-                                    runDirectory,
-                                    procEnv,
-                                    listener,
-                                    outputHandler,
-                                    liveExecution,
-                                    approvalTimeout,
-                                    prompt,
-                                    acpExecution);
-                } else {
-                    Launcher.ProcStarter procStarter =
-                            launcher.launch()
-                                    .cmds(command)
-                                    .pwd(runDirectory)
-                                    .envs(procEnv)
-                                    .stdout(stdoutSink)
-                                    .stderr(stderrSink)
-                                    .quiet(true);
-                    if (disableInteractive) {
-                        procStarter.stdin(InputStream.nullInputStream());
-                    }
-                    Proc proc = procStarter.start();
-                    outputHandler.attach(proc);
-                    try {
-                        exitCode = proc.join();
-                        outputHandler.awaitTermination();
-                    } catch (IOException | InterruptedException e) {
-                        outputHandler.requestTermination();
-                        try {
-                            outputHandler.awaitTermination();
-                        } catch (IOException | InterruptedException terminationFailure) {
-                            if (terminationFailure != e) {
-                                e.addSuppressed(terminationFailure);
-                            }
-                        }
-                        throw e;
-                    }
-                }
-            } finally {
+                AgentOutputHandler outputHandler = null;
+                boolean registered = false;
                 try {
-                    if (outputHandler != null) {
-                        outputHandler.close();
+                    File rawLogFile = action.getRawLogFile(invocationId);
+                    Files.deleteIfExists(rawLogFile.toPath());
+
+                    ExecutionRegistry.LiveExecution liveExecution =
+                            ExecutionRegistry.register(run, invocationId);
+                    registered = true;
+                    Duration approvalTimeout =
+                            Duration.ofSeconds(
+                                    Math.max(1, resolvedConfig.getApprovalTimeoutSeconds()));
+
+                    outputHandler =
+                            new AgentOutputHandler(
+                                    listener.getLogger(),
+                                    rawLogFile,
+                                    liveExecution,
+                                    sensitiveValues);
+                    OutputStream stdoutSink = new NonClosingSynchronizedOutputStream(outputHandler);
+                    OutputStream stderrSink = new NonClosingSynchronizedOutputStream(outputHandler);
+
+                    if (acpExecution != null) {
+                        exitCode =
+                                executeAcpProcess(
+                                        launcher,
+                                        command,
+                                        runDirectory,
+                                        procEnv,
+                                        listener,
+                                        outputHandler,
+                                        liveExecution,
+                                        approvalTimeout,
+                                        prompt,
+                                        acpExecution);
+                    } else {
+                        Launcher.ProcStarter procStarter =
+                                launcher.launch()
+                                        .cmds(command)
+                                        .pwd(runDirectory)
+                                        .envs(procEnv)
+                                        .stdout(stdoutSink)
+                                        .stderr(stderrSink)
+                                        .quiet(true);
+                        if (disableInteractive) {
+                            procStarter.stdin(InputStream.nullInputStream());
+                        }
+                        Proc proc = procStarter.start();
+                        outputHandler.attach(proc);
+                        try {
+                            exitCode = proc.join();
+                            outputHandler.awaitTermination();
+                        } catch (IOException | InterruptedException e) {
+                            outputHandler.requestTermination();
+                            try {
+                                outputHandler.awaitTermination();
+                            } catch (IOException | InterruptedException terminationFailure) {
+                                if (terminationFailure != e) {
+                                    e.addSuppressed(terminationFailure);
+                                }
+                            }
+                            throw e;
+                        }
                     }
                 } finally {
-                    if (registered) {
-                        ExecutionRegistry.unregister(run, invocationId);
+                    try {
+                        if (outputHandler != null) {
+                            outputHandler.close();
+                        }
+                    } finally {
+                        if (registered) {
+                            ExecutionRegistry.unregister(run, invocationId);
+                        }
                     }
                 }
+                return exitCode;
+            } catch (IOException | InterruptedException | RuntimeException | Error e) {
+                executionFailure = e;
+                throw e;
+            } finally {
+                try {
+                    action.markCompleted(invocationId, exitCode);
+                } catch (IOException completionFailure) {
+                    if (executionFailure == null) {
+                        throw completionFailure;
+                    }
+                    executionFailure.addSuppressed(completionFailure);
+                }
             }
-
-            if (outputHandler.wasDeniedByApproval()) {
-                exitCode = 1;
-            }
-            action.markCompleted(invocationId, exitCode);
-            return exitCode;
         } finally {
             try {
                 if (tempSetupScript != null) {
@@ -346,6 +360,7 @@ final class AiAgentExecutor {
             String commandOverride) {
         StringBuilder sb = new StringBuilder();
         appendShebangAwarePreamble(sb, setupScript, shellEnvironment);
+        sb.append("set +x\n");
         if (!commandOverride.isEmpty()) {
             String cmd = commandOverride;
             sb.append(cmd);
@@ -371,6 +386,7 @@ final class AiAgentExecutor {
                 end = normalizedSetupScript.length();
             }
             sb.append(normalizedSetupScript, 0, end).append('\n');
+            sb.append("set +x\n");
             appendShellExports(sb, shellEnvironment);
             if (end < normalizedSetupScript.length()) {
                 sb.append(normalizedSetupScript.substring(end + 1));
@@ -380,6 +396,7 @@ final class AiAgentExecutor {
             }
             return;
         }
+        sb.append("set +x\n");
         appendShellExports(sb, shellEnvironment);
         sb.append(normalizedSetupScript);
         if (!normalizedSetupScript.isEmpty() && !normalizedSetupScript.endsWith("\n")) {
@@ -409,14 +426,14 @@ final class AiAgentExecutor {
             throws IOException, InterruptedException {
         FilePath tempDir = AiAgentTempFiles.tempRoot(workspace);
         FilePath tempScript = tempDir.createTextTempFile("ai-agent-setup", ".sh", combinedScript);
-        tempScript.chmod(0755);
+        tempScript.chmod(0700);
         return tempScript;
     }
 
     /**
      * Builds the shell command to run the combined script, honoring a shebang line the same way the
      * Jenkins Shell build step does: if the script starts with {@code #!}, that interpreter is
-     * used; otherwise {@code /bin/sh -xe} is used as the default.
+     * used; otherwise {@code /bin/sh -e} is used as the default.
      */
     private static List<String> buildShellCommand(String setupScript, FilePath tempScript) {
         if (setupScript.startsWith("#!")) {
@@ -428,7 +445,7 @@ final class AiAgentExecutor {
             args.add(tempScript.getRemote());
             return args;
         }
-        return List.of("/bin/sh", "-xe", tempScript.getRemote());
+        return List.of("/bin/sh", "-e", tempScript.getRemote());
     }
 
     private static String shellQuote(String s) {
@@ -451,6 +468,99 @@ final class AiAgentExecutor {
             return workspace;
         }
         return workspace.child(trimmed);
+    }
+
+    private static final class ResolvedAiAgentConfiguration implements AiAgentConfiguration {
+        private final AiAgentConfiguration delegate;
+        private final String model;
+        private final String reasoningEffort;
+
+        ResolvedAiAgentConfiguration(
+                AiAgentConfiguration delegate, String model, String reasoningEffort) {
+            this.delegate = delegate;
+            this.model = model;
+            this.reasoningEffort = reasoningEffort;
+        }
+
+        @Override
+        public AiAgentTypeHandler getAgent() {
+            return delegate.getAgent();
+        }
+
+        @Override
+        public String getModel() {
+            return model;
+        }
+
+        @Override
+        public String getReasoningEffort() {
+            return reasoningEffort;
+        }
+
+        @Override
+        public String getPrompt() {
+            return delegate.getPrompt();
+        }
+
+        @Override
+        public String getWorkingDirectory() {
+            return delegate.getWorkingDirectory();
+        }
+
+        @Override
+        public boolean isYoloMode() {
+            return delegate.isYoloMode();
+        }
+
+        @Override
+        public boolean isRequireApprovals() {
+            return delegate.isRequireApprovals();
+        }
+
+        @Override
+        public int getApprovalTimeoutSeconds() {
+            return delegate.getApprovalTimeoutSeconds();
+        }
+
+        @Override
+        public String getCommandOverride() {
+            return delegate.getCommandOverride();
+        }
+
+        @Override
+        public String getExtraArgs() {
+            return delegate.getExtraArgs();
+        }
+
+        @Override
+        public String getEnvironmentVariables() {
+            return delegate.getEnvironmentVariables();
+        }
+
+        @Override
+        public boolean isFailOnAgentError() {
+            return delegate.isFailOnAgentError();
+        }
+
+        @Override
+        public String getSetupScript() {
+            return delegate.getSetupScript();
+        }
+
+        @Override
+        public String getApiCredentialsId() {
+            return delegate.getApiCredentialsId();
+        }
+
+        @Override
+        public String getEffectiveApiKeyEnvVar() {
+            return delegate.getEffectiveApiKeyEnvVar();
+        }
+
+        @Override
+        public boolean isDisableInteractive() {
+            return delegate.isDisableInteractive();
+        }
     }
 
     /**
@@ -493,26 +603,17 @@ final class AiAgentExecutor {
         private final OutputStream logger;
         private final BufferedWriter rawWriter;
         private final ExecutionRegistry.LiveExecution liveExecution;
-        private final boolean approvalsEnabled;
-        private final Duration approvalTimeout;
-        private final AiAgentLogFormat logFormat;
         private final Pattern sensitivePattern;
-        private final AiAgentLogParser.ParseState parseState = new AiAgentLogParser.ParseState();
-        private final AtomicLong lineCounter = new AtomicLong();
         private final Object terminationLock = new Object();
         private volatile Proc proc;
         private volatile boolean terminationRequested;
         private volatile Thread terminationThread;
         private volatile IOException terminationFailure;
-        private volatile boolean deniedByApproval;
 
         AgentOutputHandler(
                 OutputStream logger,
                 File rawLogFile,
                 ExecutionRegistry.LiveExecution liveExecution,
-                boolean approvalsEnabled,
-                Duration approvalTimeout,
-                AiAgentLogFormat logFormat,
                 List<String> sensitiveValues)
                 throws IOException {
             this.logger = logger;
@@ -522,9 +623,6 @@ final class AiAgentExecutor {
                                     Files.newOutputStream(rawLogFile.toPath()),
                                     StandardCharsets.UTF_8));
             this.liveExecution = liveExecution;
-            this.approvalsEnabled = approvalsEnabled;
-            this.approvalTimeout = approvalTimeout;
-            this.logFormat = logFormat;
             this.sensitivePattern =
                     SecretPatterns.getAggregateSecretPattern(
                             expandSensitiveValues(sensitiveValues));
@@ -586,10 +684,6 @@ final class AiAgentExecutor {
             thread.start();
         }
 
-        boolean wasDeniedByApproval() {
-            return deniedByApproval;
-        }
-
         @Override
         protected synchronized void eol(byte[] b, int len) throws IOException {
             String line = new String(b, 0, len, StandardCharsets.UTF_8);
@@ -609,46 +703,6 @@ final class AiAgentExecutor {
             rawWriter.write(line);
             rawWriter.newLine();
             rawWriter.flush();
-
-            if (!approvalsEnabled) {
-                return;
-            }
-
-            long id = lineCounter.incrementAndGet();
-            for (AiAgentLogParser.ParsedLine parsedLine :
-                    AiAgentLogParser.parseLines(id, line, logFormat)) {
-                if (!parseState.shouldEmit(parsedLine)) {
-                    continue;
-                }
-                if (!parsedLine.isToolCall()) {
-                    continue;
-                }
-
-                ExecutionRegistry.PendingApproval pending =
-                        liveExecution.createPendingApproval(
-                                parsedLine.getToolCallIdOrGenerated(),
-                                parsedLine.getToolName(),
-                                parsedLine.getSummary());
-                writeStatus(
-                        "Approval required: "
-                                + pending.getToolName()
-                                + " ("
-                                + pending.getToolCallId()
-                                + ")");
-
-                ExecutionRegistry.ApprovalDecision decision =
-                        liveExecution.awaitDecision(pending, approvalTimeout);
-                if (!decision.isApproved()) {
-                    deniedByApproval = true;
-                    try {
-                        writeStatus("Approval denied: " + decision.getReason());
-                    } finally {
-                        requestTermination();
-                    }
-                    return;
-                }
-                writeStatus("Approval granted: " + pending.getToolName());
-            }
         }
 
         private String maskSensitiveValues(String value) {
@@ -664,14 +718,22 @@ final class AiAgentExecutor {
                 if (sensitiveValue == null || sensitiveValue.isEmpty()) {
                     continue;
                 }
-                expanded.add(sensitiveValue);
+                addSensitiveValueVariants(expanded, sensitiveValue);
                 for (String line : sensitiveValue.split("\\R")) {
                     if (!line.isEmpty()) {
-                        expanded.add(line);
+                        addSensitiveValueVariants(expanded, line);
                     }
                 }
             }
             return expanded;
+        }
+
+        private static void addSensitiveValueVariants(List<String> expanded, String value) {
+            expanded.add(value);
+            String jsonEscaped = JSONUtils.stripQuotes(JSONUtils.quote(value));
+            if (!jsonEscaped.equals(value)) {
+                expanded.add(jsonEscaped);
+            }
         }
 
         synchronized void writeStatus(String message) throws IOException {

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentLogFormat.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentLogFormat.java
@@ -2,6 +2,8 @@ package io.jenkins.plugins.aiagentjob;
 
 import net.sf.json.JSONObject;
 
+import java.util.List;
+
 /**
  * Strategy interface for classifying a JSON log line emitted by an AI agent into a {@link
  * AiAgentLogParser.ParsedLine}.
@@ -24,4 +26,16 @@ public interface AiAgentLogFormat {
      *     not handle the given JSON structure
      */
     AiAgentLogParser.ParsedLine classify(long lineNumber, JSONObject json);
+
+    /**
+     * Attempt to classify a JSON object that may contain multiple displayable events.
+     *
+     * <p>Implementations that emit at most one event can rely on this default. Returning {@code
+     * null} still means the format did not recognize the input; an empty list means it recognized
+     * the input but intentionally produced no visible events.
+     */
+    default List<AiAgentLogParser.ParsedLine> classifyAll(long lineNumber, JSONObject json) {
+        AiAgentLogParser.ParsedLine parsed = classify(lineNumber, json);
+        return parsed == null ? null : List.of(parsed);
+    }
 }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentLogParser.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentLogParser.java
@@ -2,7 +2,6 @@ package io.jenkins.plugins.aiagentjob;
 
 import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeLogFormat;
 
-import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 import java.io.BufferedReader;
@@ -13,8 +12,10 @@ import java.nio.file.Files;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * Parses JSONL output from AI agents into classified {@link EventView} objects.
@@ -49,34 +50,37 @@ public final class AiAgentLogParser {
             return Collections.emptyList();
         }
         List<EventView> events = new ArrayList<>();
-        String lastAssistantContent = "";
+        EventView lastAssistantEvent = null;
+        ParseState parseState = new ParseState();
         try (BufferedReader reader =
                 Files.newBufferedReader(rawLogFile.toPath(), StandardCharsets.UTF_8)) {
             String line;
             long idx = 0;
             while ((line = reader.readLine()) != null) {
                 idx++;
-                EventView ev = parseLine(idx, line, format).toEventView();
-                if (ev.isEmpty()) continue;
+                for (ParsedLine parsedLine : parseLines(idx, line, format)) {
+                    if (!parseState.shouldEmit(parsedLine)) continue;
+                    EventView ev = parsedLine.toEventView();
+                    if (ev.isEmpty()) continue;
 
-                if (mergeAssistantDelta(events, ev)) {
-                    EventView merged = events.get(events.size() - 1);
-                    lastAssistantContent = merged.getContent();
-                    continue;
-                }
+                    if (mergeDelta(events, ev)) {
+                        if ("assistant".equals(ev.getCategory())) {
+                            lastAssistantEvent = events.get(events.size() - 1);
+                        }
+                        continue;
+                    }
 
-                if ("assistant".equals(ev.getCategory()) && !ev.getContent().isEmpty()) {
-                    lastAssistantContent = ev.getContent();
-                }
+                    if ("assistant".equals(ev.getCategory()) && !ev.getContent().isEmpty()) {
+                        lastAssistantEvent = ev;
+                    }
 
-                if ("result".equals(ev.getCategory())
-                        && !ev.getContent().isEmpty()
-                        && !lastAssistantContent.isEmpty()
-                        && ev.getContent().contains(lastAssistantContent)) {
-                    continue;
-                }
+                    if ("result".equals(ev.getCategory())
+                            && !ev.getContent().isEmpty()
+                            && lastAssistantEvent != null
+                            && ev.getContent().contains(lastAssistantEvent.getContent())) {
+                        continue;
+                    }
 
-                if (!ev.isEmpty()) {
                     events.add(ev);
                 }
             }
@@ -84,32 +88,22 @@ public final class AiAgentLogParser {
         return events;
     }
 
-    private static boolean mergeAssistantDelta(List<EventView> events, EventView ev) {
-        if (!ev.isDelta() || !"assistant".equals(ev.getCategory()) || ev.getContent().isEmpty()) {
+    private static boolean mergeDelta(List<EventView> events, EventView ev) {
+        if (!ev.isDelta() || ev.getContent().isEmpty()) {
+            return false;
+        }
+        if (!"assistant".equals(ev.getCategory()) && !"thinking".equals(ev.getCategory())) {
             return false;
         }
         if (events.isEmpty()) {
             return false;
         }
         EventView previous = events.get(events.size() - 1);
-        if (!"assistant".equals(previous.getCategory())) {
+        if (!ev.getCategory().equals(previous.getCategory())) {
             return false;
         }
 
-        String mergedContent = previous.getContent() + ev.getContent();
-        String mergedRaw = previous.getRawDetails() + "\n" + ev.getRawDetails();
-        EventView merged =
-                new EventView(
-                        previous.getId(),
-                        previous.getCategory(),
-                        previous.getLabel(),
-                        mergedContent,
-                        previous.getToolInput(),
-                        previous.getToolOutput(),
-                        mergedRaw,
-                        ev.getTimestamp(),
-                        false);
-        events.set(events.size() - 1, merged);
+        previous.appendDelta(ev);
         return true;
     }
 
@@ -118,33 +112,43 @@ public final class AiAgentLogParser {
     }
 
     public static ParsedLine parseLine(long lineNumber, String line, AiAgentLogFormat format) {
+        List<ParsedLine> parsedLines = parseLines(lineNumber, line, format);
+        return parsedLines.isEmpty() ? ParsedLine.raw(lineNumber, "") : parsedLines.get(0);
+    }
+
+    static List<ParsedLine> parseLines(long lineNumber, String line, AiAgentLogFormat format) {
         if (line == null) {
-            return ParsedLine.raw(lineNumber, "");
+            return List.of(ParsedLine.raw(lineNumber, ""));
         }
         String trimmed = line.trim();
         if (trimmed.isEmpty()) {
-            return ParsedLine.raw(lineNumber, "");
+            return List.of(ParsedLine.raw(lineNumber, ""));
         }
 
         JSONObject json = tryParseJson(trimmed);
         if (json == null) {
-            return ParsedLine.raw(lineNumber, trimmed);
+            return List.of(ParsedLine.raw(lineNumber, trimmed));
         }
         return classifyJson(lineNumber, json, format);
     }
 
-    private static ParsedLine classifyJson(
+    private static List<ParsedLine> classifyJson(
             long lineNumber, JSONObject json, AiAgentLogFormat format) {
         // 1) Try the handler-specific format first
         if (format != null) {
-            ParsedLine result = format.classify(lineNumber, json);
+            List<ParsedLine> result = format.classifyAll(lineNumber, json);
             if (result != null) {
                 return result;
             }
         }
 
+        List<ParsedLine> claudeResult = ClaudeCodeLogFormat.INSTANCE.classifyAll(lineNumber, json);
+        if (claudeResult != null) {
+            return claudeResult;
+        }
+
         // 2) Shared format: common types across multiple agents
-        return classifySharedFormat(lineNumber, json);
+        return List.of(classifySharedFormat(lineNumber, json));
     }
 
     /**
@@ -225,11 +229,6 @@ public final class AiAgentLogParser {
         if (typeLower.equals("assistant") || typeLower.equals("user")) {
             JSONObject message = json.optJSONObject("message");
             if (message != null) {
-                JSONArray contentArr = message.optJSONArray("content");
-                if (contentArr != null && contentArr.size() > 0) {
-                    return ClaudeCodeLogFormat.classifyContentArray(
-                            lineNumber, typeLower, contentArr, rawDetails);
-                }
                 String msgText = LogFormatUtils.extractText(message);
                 String cat = typeLower.equals("assistant") ? "assistant" : "user";
                 return ParsedLine.message(
@@ -321,6 +320,18 @@ public final class AiAgentLogParser {
         }
     }
 
+    static final class ParseState {
+        private final Map<String, String> fingerprints = new HashMap<>();
+
+        boolean shouldEmit(ParsedLine parsedLine) {
+            if (parsedLine.deduplicationKey == null || parsedLine.deduplicationKey.isEmpty()) {
+                return true;
+            }
+            String fingerprint = parsedLine.deduplicationFingerprint();
+            return !fingerprint.equals(fingerprints.put(parsedLine.deduplicationKey, fingerprint));
+        }
+    }
+
     // ---- Data classes ----
 
     public static final class ParsedLine {
@@ -334,6 +345,7 @@ public final class AiAgentLogParser {
         private final String rawDetails;
         private final String toolCallId;
         private final boolean delta;
+        private final String deduplicationKey;
         private final Instant timestamp;
 
         private ParsedLine(
@@ -347,6 +359,34 @@ public final class AiAgentLogParser {
                 String rawDetails,
                 String toolCallId,
                 boolean delta) {
+            this(
+                    id,
+                    category,
+                    label,
+                    content,
+                    toolInput,
+                    toolOutput,
+                    toolName,
+                    rawDetails,
+                    toolCallId,
+                    delta,
+                    null,
+                    Instant.now());
+        }
+
+        private ParsedLine(
+                long id,
+                String category,
+                String label,
+                String content,
+                String toolInput,
+                String toolOutput,
+                String toolName,
+                String rawDetails,
+                String toolCallId,
+                boolean delta,
+                String deduplicationKey,
+                Instant timestamp) {
             this.id = id;
             this.category = category;
             this.label = label;
@@ -357,7 +397,8 @@ public final class AiAgentLogParser {
             this.rawDetails = rawDetails;
             this.toolCallId = toolCallId;
             this.delta = delta;
-            this.timestamp = Instant.now();
+            this.deduplicationKey = deduplicationKey;
+            this.timestamp = timestamp;
         }
 
         public static ParsedLine raw(long id, String line) {
@@ -393,8 +434,13 @@ public final class AiAgentLogParser {
         }
 
         public static ParsedLine thinking(long id, String content, String rawDetails) {
+            return thinking(id, content, rawDetails, false);
+        }
+
+        public static ParsedLine thinking(
+                long id, String content, String rawDetails, boolean delta) {
             return new ParsedLine(
-                    id, "thinking", "Thinking", content, "", "", "", rawDetails, null, false);
+                    id, "thinking", "Thinking", content, "", "", "", rawDetails, null, delta);
         }
 
         public static ParsedLine toolCall(
@@ -455,6 +501,35 @@ public final class AiAgentLogParser {
             return label;
         }
 
+        public ParsedLine withDeduplicationKey(String key) {
+            if (key == null || key.isEmpty()) return this;
+            return new ParsedLine(
+                    id,
+                    category,
+                    label,
+                    content,
+                    toolInput,
+                    toolOutput,
+                    toolName,
+                    rawDetails,
+                    toolCallId,
+                    delta,
+                    key,
+                    timestamp);
+        }
+
+        private String deduplicationFingerprint() {
+            return category
+                    + '\0'
+                    + content
+                    + '\0'
+                    + toolInput
+                    + '\0'
+                    + toolOutput
+                    + '\0'
+                    + toolCallId;
+        }
+
         EventView toEventView() {
             return new EventView(
                     id,
@@ -479,12 +554,12 @@ public final class AiAgentLogParser {
         private final long id;
         private final String category;
         private final String label;
-        private final String content;
+        private final StringBuilder content;
         private final String toolInput;
         private final String toolOutput;
-        private final String rawDetails;
-        private final Instant timestamp;
-        private final boolean delta;
+        private final StringBuilder rawDetails;
+        private Instant timestamp;
+        private boolean delta;
 
         EventView(
                 long id,
@@ -499,10 +574,10 @@ public final class AiAgentLogParser {
             this.id = id;
             this.category = category;
             this.label = label;
-            this.content = content;
+            this.content = new StringBuilder(content);
             this.toolInput = toolInput;
             this.toolOutput = toolOutput;
-            this.rawDetails = rawDetails;
+            this.rawDetails = new StringBuilder(rawDetails);
             this.timestamp = timestamp;
             this.delta = delta;
         }
@@ -522,7 +597,7 @@ public final class AiAgentLogParser {
 
         /** Full text content for messages, results, and thinking. */
         public String getContent() {
-            return content;
+            return content.toString();
         }
 
         /** Tool input: command text, file path, etc. */
@@ -537,7 +612,7 @@ public final class AiAgentLogParser {
 
         /** Raw JSON for the detail drill-down. */
         public String getRawDetails() {
-            return rawDetails;
+            return rawDetails.toString();
         }
 
         public Instant getTimestamp() {
@@ -554,8 +629,9 @@ public final class AiAgentLogParser {
 
         /** One-line summary for progressive events API backwards compat. */
         public String getSummary() {
-            if (!content.isEmpty()) {
-                String compact = content.replaceAll("\\s+", " ").trim();
+            String contentText = getContent();
+            if (!contentText.isEmpty()) {
+                String compact = contentText.replaceAll("\\s+", " ").trim();
                 if (compact.length() > 180) compact = compact.substring(0, 177) + "...";
                 return label + ": " + compact;
             }
@@ -569,7 +645,7 @@ public final class AiAgentLogParser {
 
         public boolean isEmpty() {
             if ("raw".equals(category)) {
-                return content == null || content.trim().isEmpty();
+                return content.toString().trim().isEmpty();
             }
             return false;
         }
@@ -589,7 +665,17 @@ public final class AiAgentLogParser {
 
         /** Returns content converted from markdown to basic HTML for display in Jelly. */
         public String getContentHtml() {
-            return markdownToHtml(content);
+            return markdownToHtml(getContent());
+        }
+
+        private void appendDelta(EventView event) {
+            content.append(event.content);
+            if (!rawDetails.isEmpty() && !event.rawDetails.isEmpty()) {
+                rawDetails.append('\n');
+            }
+            rawDetails.append(event.rawDetails);
+            timestamp = event.timestamp;
+            delta = false;
         }
 
         static String markdownToHtml(String md) {

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentLogParser.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentLogParser.java
@@ -345,7 +345,11 @@ public final class AiAgentLogParser {
         private final String rawDetails;
         private final String toolCallId;
         private final boolean delta;
+
+        // Ephemeral parser identity, not a credential or persisted value.
+        @SuppressWarnings("lgtm[jenkins/plaintext-storage]")
         private final String deduplicationKey;
+
         private final Instant timestamp;
 
         private ParsedLine(

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentRunAction.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentRunAction.java
@@ -32,12 +32,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Per-build action that stores AI agent invocation metadata and provides the inline conversation
  * view on the build page. Supports multiple invocations in a single build.
  */
 public class AiAgentRunAction implements Action, RunAction2 {
+    private static final Logger LOGGER = Logger.getLogger(AiAgentRunAction.class.getName());
     private static final String RAW_LOG_FILE_PREFIX = "ai-agent-stream-";
     private static final String RAW_LOG_FILE_SUFFIX = ".jsonl";
 
@@ -76,12 +79,14 @@ public class AiAgentRunAction implements Action, RunAction2 {
     public void onAttached(Run<?, ?> run) {
         initializeTransientState();
         this.run = run;
+        clearSensitiveInvocationMetadata();
     }
 
     @Override
     public void onLoad(Run<?, ?> run) {
         initializeTransientState();
         this.run = run;
+        clearSensitiveInvocationMetadata();
     }
 
     public int markStarted(
@@ -94,13 +99,14 @@ public class AiAgentRunAction implements Action, RunAction2 {
             throws IOException {
         synchronized (stateLock) {
             int id = nextInvocationId++;
+            // Prompt and command values may contain credentials expanded by Pipeline or EnvVars.
             InvocationRecord invocation =
                     new InvocationRecord(
                             id,
                             agentTypeDisplayName == null ? "" : agentTypeDisplayName,
-                            prompt == null ? "" : prompt,
+                            "",
                             model == null ? "" : model,
-                            commandLine == null ? "" : commandLine,
+                            "",
                             yoloMode,
                             approvalsEnabled,
                             System.currentTimeMillis());
@@ -522,6 +528,7 @@ public class AiAgentRunAction implements Action, RunAction2 {
 
         File raw = getRawLogFile(invocationId);
         List<AiAgentLogParser.EventView> newEvents = new ArrayList<>();
+        AiAgentLogParser.ParseState parseState = new AiAgentLogParser.ParseState();
         long lineCount = 0;
 
         if (raw != null && raw.exists()) {
@@ -531,13 +538,15 @@ public class AiAgentRunAction implements Action, RunAction2 {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     lineCount++;
-                    if (lineCount <= startLine) {
-                        continue;
-                    }
-                    AiAgentLogParser.EventView ev =
-                            AiAgentLogParser.parseLine(lineCount, line, format).toEventView();
-                    if (!ev.isEmpty()) {
-                        newEvents.add(ev);
+                    for (AiAgentLogParser.ParsedLine parsedLine :
+                            AiAgentLogParser.parseLines(lineCount, line, format)) {
+                        if (!parseState.shouldEmit(parsedLine) || lineCount <= startLine) {
+                            continue;
+                        }
+                        AiAgentLogParser.EventView ev = parsedLine.toEventView();
+                        if (!ev.isEmpty()) {
+                            newEvents.add(ev);
+                        }
                     }
                 }
             }
@@ -655,6 +664,33 @@ public class AiAgentRunAction implements Action, RunAction2 {
         }
     }
 
+    private void clearSensitiveInvocationMetadata() {
+        boolean changed = false;
+        synchronized (stateLock) {
+            for (InvocationRecord invocation : invocations) {
+                if (invocation.prompt != null && !invocation.prompt.isEmpty()) {
+                    invocation.prompt = "";
+                    changed = true;
+                }
+                if (invocation.commandLine != null && !invocation.commandLine.isEmpty()) {
+                    invocation.commandLine = "";
+                    changed = true;
+                }
+            }
+        }
+        if (changed && run != null) {
+            try {
+                run.save();
+            } catch (IOException e) {
+                LOGGER.log(
+                        Level.WARNING,
+                        "Could not persist removal of sensitive AI agent invocation metadata from "
+                                + run.getExternalizableId(),
+                        e);
+            }
+        }
+    }
+
     private int resolveRequestedInvocationId() {
         StaplerRequest2 request = Stapler.getCurrentRequest2();
         if (request != null) {
@@ -704,9 +740,9 @@ public class AiAgentRunAction implements Action, RunAction2 {
 
         private final int id;
         private final String agentType;
-        private final String prompt;
+        private String prompt;
         private final String model;
-        private final String commandLine;
+        private String commandLine;
         private final boolean yoloMode;
         private final boolean approvalsEnabled;
         private final long startedAtMillis;

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentTypeHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentTypeHandler.java
@@ -31,6 +31,9 @@ public abstract class AiAgentTypeHandler extends AbstractDescribableImpl<AiAgent
 
     public abstract String getDefaultApiKeyEnvVar();
 
+    /** Rejects unsupported execution settings before any process or temporary file is created. */
+    public void validateExecution(AiAgentConfiguration config) {}
+
     public abstract List<String> buildDefaultCommand(AiAgentConfiguration config, String prompt);
 
     /**

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentTypeHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentTypeHandler.java
@@ -32,13 +32,33 @@ public abstract class AiAgentTypeHandler extends AbstractDescribableImpl<AiAgent
     public abstract String getDefaultApiKeyEnvVar();
 
     /** Rejects unsupported execution settings before any process or temporary file is created. */
-    public void validateExecution(AiAgentConfiguration config) {}
+    public void validateExecution(AiAgentConfiguration config) {
+        if (!config.isRequireApprovals() || config.isYoloMode()) {
+            return;
+        }
+        String commandOverride = config.getCommandOverride();
+        if (commandOverride != null && !commandOverride.trim().isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Manual approvals cannot be used with a command override because Jenkins "
+                            + "has no bidirectional approval channel for that process.");
+        }
+        if (!supportsManualApprovals()) {
+            throw new IllegalArgumentException(
+                    "Manual approvals require an ACP-capable agent. Disable manual approvals or "
+                            + "use OpenCode.");
+        }
+    }
+
+    /** Whether this handler provides a bidirectional Jenkins approval channel. */
+    public boolean supportsManualApprovals() {
+        return false;
+    }
 
     public abstract List<String> buildDefaultCommand(AiAgentConfiguration config, String prompt);
 
     /**
-     * Returns an ACP server command when this agent needs a bidirectional approval channel, or
-     * {@code null} when its normal command handles approvals directly.
+     * Returns an ACP server command for a bidirectional approval channel, or {@code null} when
+     * manual approvals are unsupported.
      */
     public AcpExecutionSpec buildAcpExecution(AiAgentConfiguration config) {
         return null;

--- a/src/main/java/io/jenkins/plugins/aiagentjob/ExecutionRegistry.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/ExecutionRegistry.java
@@ -47,14 +47,20 @@ public final class ExecutionRegistry {
         private final Map<String, PendingApproval> pendingApprovals = new ConcurrentHashMap<>();
         private final Map<String, CompletableFuture<ApprovalDecision>> decisions =
                 new ConcurrentHashMap<>();
+        private String cancellationReason;
 
-        PendingApproval createPendingApproval(
+        synchronized PendingApproval createPendingApproval(
                 String toolCallId, String toolName, String inputSummary) {
             String id = UUID.randomUUID().toString();
             PendingApproval pending =
                     new PendingApproval(id, toolCallId, toolName, inputSummary, Instant.now());
-            decisions.put(id, new CompletableFuture<>());
-            pendingApprovals.put(id, pending);
+            CompletableFuture<ApprovalDecision> decision = new CompletableFuture<>();
+            decisions.put(id, decision);
+            if (cancellationReason == null) {
+                pendingApprovals.put(id, pending);
+            } else {
+                decision.complete(ApprovalDecision.denied(cancellationReason));
+            }
             return pending;
         }
 
@@ -113,8 +119,9 @@ public final class ExecutionRegistry {
             return completed;
         }
 
-        void cancelPendingApprovals(String reason) {
+        synchronized void cancelPendingApprovals(String reason) {
             ApprovalDecision cancelled = ApprovalDecision.denied(reason);
+            cancellationReason = cancelled.getReason();
             for (Map.Entry<String, CompletableFuture<ApprovalDecision>> entry :
                     decisions.entrySet()) {
                 entry.getValue().complete(cancelled);

--- a/src/main/java/io/jenkins/plugins/aiagentjob/ExecutionRegistry.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/ExecutionRegistry.java
@@ -58,7 +58,8 @@ public final class ExecutionRegistry {
             return pending;
         }
 
-        ApprovalDecision awaitDecision(PendingApproval pendingApproval, Duration timeout) {
+        ApprovalDecision awaitDecision(PendingApproval pendingApproval, Duration timeout)
+                throws InterruptedException {
             CompletableFuture<ApprovalDecision> future = decisions.get(pendingApproval.getId());
             if (future == null) {
                 return ApprovalDecision.denied("approval request disappeared");
@@ -66,11 +67,8 @@ public final class ExecutionRegistry {
             try {
                 return future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                ApprovalDecision interrupted =
-                        ApprovalDecision.denied("interrupted while waiting for approval");
-                future.complete(interrupted);
-                return future.getNow(interrupted);
+                future.complete(ApprovalDecision.denied("interrupted while waiting for approval"));
+                throw e;
             } catch (ExecutionException e) {
                 return ApprovalDecision.denied("approval failed: " + e.getMessage());
             } catch (TimeoutException e) {

--- a/src/main/java/io/jenkins/plugins/aiagentjob/ExecutionRegistry.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/ExecutionRegistry.java
@@ -53,8 +53,8 @@ public final class ExecutionRegistry {
             String id = UUID.randomUUID().toString();
             PendingApproval pending =
                     new PendingApproval(id, toolCallId, toolName, inputSummary, Instant.now());
-            pendingApprovals.put(id, pending);
             decisions.put(id, new CompletableFuture<>());
+            pendingApprovals.put(id, pending);
             return pending;
         }
 
@@ -64,20 +64,24 @@ public final class ExecutionRegistry {
                 return ApprovalDecision.denied("approval request disappeared");
             }
             try {
-                ApprovalDecision decision = future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
-                pendingApprovals.remove(pendingApproval.getId());
-                decisions.remove(pendingApproval.getId());
-                return decision;
+                return future.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
-                return ApprovalDecision.denied("interrupted while waiting for approval");
+                ApprovalDecision interrupted =
+                        ApprovalDecision.denied("interrupted while waiting for approval");
+                future.complete(interrupted);
+                return future.getNow(interrupted);
             } catch (ExecutionException e) {
                 return ApprovalDecision.denied("approval failed: " + e.getMessage());
             } catch (TimeoutException e) {
-                pendingApprovals.remove(pendingApproval.getId());
-                decisions.remove(pendingApproval.getId());
-                return ApprovalDecision.denied(
-                        "approval timed out after " + timeout.toSeconds() + "s");
+                ApprovalDecision timedOut =
+                        ApprovalDecision.denied(
+                                "approval timed out after " + timeout.toSeconds() + "s");
+                future.complete(timedOut);
+                return future.getNow(timedOut);
+            } finally {
+                pendingApprovals.remove(pendingApproval.getId(), pendingApproval);
+                decisions.remove(pendingApproval.getId(), future);
             }
         }
 
@@ -95,7 +99,6 @@ public final class ExecutionRegistry {
             boolean completed = future.complete(ApprovalDecision.approved());
             if (completed) {
                 pendingApprovals.remove(id);
-                decisions.remove(id);
             }
             return completed;
         }
@@ -108,9 +111,17 @@ public final class ExecutionRegistry {
             boolean completed = future.complete(ApprovalDecision.denied(reason));
             if (completed) {
                 pendingApprovals.remove(id);
-                decisions.remove(id);
             }
             return completed;
+        }
+
+        void cancelPendingApprovals(String reason) {
+            ApprovalDecision cancelled = ApprovalDecision.denied(reason);
+            for (Map.Entry<String, CompletableFuture<ApprovalDecision>> entry :
+                    decisions.entrySet()) {
+                entry.getValue().complete(cancelled);
+                pendingApprovals.remove(entry.getKey());
+            }
         }
     }
 

--- a/src/main/java/io/jenkins/plugins/aiagentjob/claudecode/ClaudeCodeAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/claudecode/ClaudeCodeAgentHandler.java
@@ -41,8 +41,6 @@ public final class ClaudeCodeAgentHandler extends AiAgentTypeHandler {
         command.add("--verbose");
         if (config.isYoloMode()) {
             command.add("--dangerously-skip-permissions");
-        } else if (config.isRequireApprovals()) {
-            command.add("--permission-mode=default");
         }
         String model = Util.fixEmptyAndTrim(config.getModel());
         if (model != null) {

--- a/src/main/java/io/jenkins/plugins/aiagentjob/claudecode/ClaudeCodeLogFormat.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/claudecode/ClaudeCodeLogFormat.java
@@ -7,6 +7,9 @@ import io.jenkins.plugins.aiagentjob.LogFormatUtils;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Format-specific log classification for Claude Code stream-json output. Handles content arrays
  * (tool_use, tool_result, thinking, text) and stream_event deltas.
@@ -23,6 +26,12 @@ public final class ClaudeCodeLogFormat implements AiAgentLogFormat {
 
     @Override
     public AiAgentLogParser.ParsedLine classify(long lineNumber, JSONObject json) {
+        List<AiAgentLogParser.ParsedLine> parsed = classifyAll(lineNumber, json);
+        return parsed == null || parsed.isEmpty() ? null : parsed.get(0);
+    }
+
+    @Override
+    public List<AiAgentLogParser.ParsedLine> classifyAll(long lineNumber, JSONObject json) {
         String type = LogFormatUtils.firstNonEmpty(json, "type", "event", "kind", "subtype");
         String typeLower = LogFormatUtils.normalize(type);
 
@@ -32,8 +41,12 @@ public final class ClaudeCodeLogFormat implements AiAgentLogFormat {
             if (message != null) {
                 JSONArray contentArr = message.optJSONArray("content");
                 if (contentArr != null && contentArr.size() > 0) {
-                    return classifyContentArray(
-                            lineNumber, typeLower, contentArr, json.toString(2));
+                    return classifyContentArrayAll(
+                            lineNumber,
+                            typeLower,
+                            message.optString("id", ""),
+                            contentArr,
+                            json.toString(2));
                 }
             }
         }
@@ -42,7 +55,7 @@ public final class ClaudeCodeLogFormat implements AiAgentLogFormat {
         if (typeLower.equals("stream_event")) {
             JSONObject event = json.optJSONObject("event");
             if (event != null) {
-                return classifyStreamEvent(lineNumber, event, json.toString(2));
+                return List.of(classifyStreamEvent(lineNumber, event, json.toString(2)));
             }
         }
 
@@ -52,73 +65,120 @@ public final class ClaudeCodeLogFormat implements AiAgentLogFormat {
 
     public static AiAgentLogParser.ParsedLine classifyContentArray(
             long lineNumber, String parentType, JSONArray contentArr, String rawDetails) {
-        // Scan for tool_use first
+        return classifyContentArrayAll(lineNumber, parentType, "", contentArr, rawDetails).get(0);
+    }
+
+    private static List<AiAgentLogParser.ParsedLine> classifyContentArrayAll(
+            long lineNumber,
+            String parentType,
+            String messageId,
+            JSONArray contentArr,
+            String rawDetails) {
+        List<AiAgentLogParser.ParsedLine> parsed = new ArrayList<>();
+        StringBuilder text = new StringBuilder();
+        String category = parentType.equals("assistant") ? "assistant" : "user";
+        int textStartIndex = -1;
+
         for (int i = 0; i < contentArr.size(); i++) {
             Object obj = contentArr.get(i);
             if (!(obj instanceof JSONObject)) continue;
             JSONObject ci = (JSONObject) obj;
             String ciType = LogFormatUtils.normalize(ci.optString("type"));
 
+            if (ciType.equals("text")) {
+                String value = ci.optString("text", "");
+                if (!value.isEmpty()) {
+                    if (textStartIndex < 0) textStartIndex = i;
+                    if (text.length() > 0) text.append('\n');
+                    text.append(value);
+                }
+                continue;
+            }
+
+            addPendingText(
+                    parsed,
+                    lineNumber,
+                    category,
+                    text,
+                    rawDetails,
+                    contentKey(messageId, textStartIndex, i - 1, "text"));
+            textStartIndex = -1;
+
             if (ciType.equals("tool_use")) {
                 String toolName = LogFormatUtils.firstNonEmpty(ci, "name");
                 String toolCallId = LogFormatUtils.firstNonEmpty(ci, "id");
                 String toolInput =
                         LogFormatUtils.extractToolInput(ci.optJSONObject("input"), toolName);
-                return AiAgentLogParser.ParsedLine.toolCall(
-                        lineNumber, toolName, toolInput, rawDetails, toolCallId);
-            }
-        }
-        // Then tool_result blocks wrapped in Claude "user" turns
-        for (int i = 0; i < contentArr.size(); i++) {
-            Object obj = contentArr.get(i);
-            if (!(obj instanceof JSONObject)) continue;
-            JSONObject ci = (JSONObject) obj;
-            if ("tool_result".equals(LogFormatUtils.normalize(ci.optString("type")))) {
+                parsed.add(
+                        AiAgentLogParser.ParsedLine.toolCall(
+                                        lineNumber, toolName, toolInput, rawDetails, toolCallId)
+                                .withDeduplicationKey(
+                                        toolCallId.isEmpty()
+                                                ? contentKey(messageId, i, i, "tool-use")
+                                                : "claude-tool-use:" + toolCallId));
+            } else if (ciType.equals("tool_result")) {
                 String toolCallId =
                         LogFormatUtils.firstNonEmpty(ci, "tool_use_id", "tool_call_id", "id");
                 String toolName = LogFormatUtils.firstNonEmpty(ci, "tool_name", "name");
                 String toolOutput = LogFormatUtils.extractToolResultContent(ci);
-                if (toolOutput.isEmpty()) {
-                    return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
+                if (!toolOutput.isEmpty()) {
+                    parsed.add(
+                            AiAgentLogParser.ParsedLine.toolResult(
+                                            lineNumber,
+                                            toolName,
+                                            toolOutput,
+                                            rawDetails,
+                                            toolCallId)
+                                    .withDeduplicationKey(
+                                            toolCallId.isEmpty()
+                                                    ? contentKey(messageId, i, i, "tool-result")
+                                                    : "claude-tool-result:" + toolCallId));
                 }
-                return AiAgentLogParser.ParsedLine.toolResult(
-                        lineNumber, toolName, toolOutput, rawDetails, toolCallId);
-            }
-        }
-        // Then thinking
-        for (int i = 0; i < contentArr.size(); i++) {
-            Object obj = contentArr.get(i);
-            if (!(obj instanceof JSONObject)) continue;
-            JSONObject ci = (JSONObject) obj;
-            if ("thinking".equals(LogFormatUtils.normalize(ci.optString("type")))) {
+            } else if (ciType.equals("thinking")) {
                 String thinking = LogFormatUtils.firstNonEmpty(ci, "thinking");
-                return AiAgentLogParser.ParsedLine.thinking(lineNumber, thinking, rawDetails);
-            }
-        }
-        // Default: extract all text content
-        StringBuilder textBuilder = new StringBuilder();
-        for (int i = 0; i < contentArr.size(); i++) {
-            Object obj = contentArr.get(i);
-            if (!(obj instanceof JSONObject)) continue;
-            JSONObject ci = (JSONObject) obj;
-            if ("text".equals(ci.optString("type"))) {
-                String t = ci.optString("text", "");
-                if (!t.isEmpty()) {
-                    if (textBuilder.length() > 0) textBuilder.append('\n');
-                    textBuilder.append(t);
+                if (!thinking.isEmpty()) {
+                    parsed.add(
+                            AiAgentLogParser.ParsedLine.thinking(lineNumber, thinking, rawDetails)
+                                    .withDeduplicationKey(contentKey(messageId, i, i, "thinking")));
                 }
             }
         }
-        String cat = parentType.equals("assistant") ? "assistant" : "user";
-        if (textBuilder.length() == 0) {
-            return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
-        }
-        return AiAgentLogParser.ParsedLine.message(
+        addPendingText(
+                parsed,
                 lineNumber,
-                cat,
-                LogFormatUtils.capitalize(cat),
-                textBuilder.toString(),
-                rawDetails);
+                category,
+                text,
+                rawDetails,
+                contentKey(messageId, textStartIndex, contentArr.size() - 1, "text"));
+        if (parsed.isEmpty()) {
+            parsed.add(AiAgentLogParser.ParsedLine.raw(lineNumber, ""));
+        }
+        return parsed;
+    }
+
+    private static void addPendingText(
+            List<AiAgentLogParser.ParsedLine> parsed,
+            long lineNumber,
+            String category,
+            StringBuilder text,
+            String rawDetails,
+            String deduplicationKey) {
+        if (text.length() == 0) return;
+        parsed.add(
+                AiAgentLogParser.ParsedLine.message(
+                                lineNumber,
+                                category,
+                                LogFormatUtils.capitalize(category),
+                                text.toString(),
+                                rawDetails)
+                        .withDeduplicationKey(deduplicationKey));
+        text.setLength(0);
+    }
+
+    private static String contentKey(
+            String messageId, int startIndex, int endIndex, String blockType) {
+        if (messageId == null || messageId.isEmpty() || startIndex < 0) return null;
+        return "claude-content:" + messageId + ':' + startIndex + ':' + endIndex + ':' + blockType;
     }
 
     public static AiAgentLogParser.ParsedLine classifyStreamEvent(
@@ -132,20 +192,30 @@ public final class ClaudeCodeLogFormat implements AiAgentLogFormat {
             if (source != null) {
                 String blockType = LogFormatUtils.normalize(source.optString("type"));
                 if (blockType.contains("thinking")) {
-                    return AiAgentLogParser.ParsedLine.thinking(
-                            lineNumber,
-                            LogFormatUtils.firstNonEmpty(source, "thinking", "text"),
-                            rawDetails);
+                    String thinking = source.optString("thinking", source.optString("text", ""));
+                    return thinking.isEmpty()
+                            ? AiAgentLogParser.ParsedLine.raw(lineNumber, "")
+                            : AiAgentLogParser.ParsedLine.thinking(
+                                    lineNumber,
+                                    thinking,
+                                    rawDetails,
+                                    eventType.equals("content_block_delta"));
                 }
                 if (blockType.contains("text")) {
+                    String text = source.optString("text", "");
+                    if (text.isEmpty()) {
+                        return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
+                    }
                     return AiAgentLogParser.ParsedLine.message(
                             lineNumber,
                             "assistant",
                             "Assistant",
-                            LogFormatUtils.firstNonEmpty(source, "text"),
-                            rawDetails);
+                            text,
+                            rawDetails,
+                            eventType.equals("content_block_delta"));
                 }
             }
+            return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
         }
         if (eventType.equals("message_start")) {
             JSONObject message = event.optJSONObject("message");
@@ -156,6 +226,13 @@ public final class ClaudeCodeLogFormat implements AiAgentLogFormat {
                             lineNumber, "System", "Model: " + model, rawDetails);
                 }
             }
+            return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
+        }
+        if (eventType.equals("content_block_stop")
+                || eventType.equals("message_delta")
+                || eventType.equals("message_stop")
+                || eventType.equals("ping")) {
+            return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
         }
         return AiAgentLogParser.ParsedLine.system(
                 lineNumber, "Stream event", eventType, rawDetails);

--- a/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler.java
@@ -41,6 +41,15 @@ public final class CodexAgentHandler extends AiAgentTypeHandler {
     }
 
     @Override
+    public void validateExecution(AiAgentConfiguration config) {
+        if (config.isRequireApprovals() && !config.isYoloMode()) {
+            throw new IllegalArgumentException(
+                    "Codex CLI does not expose a non-interactive approval channel. "
+                            + "Disable manual approvals or use an agent with ACP support.");
+        }
+    }
+
+    @Override
     public List<String> buildDefaultCommand(AiAgentConfiguration config, String prompt) {
         List<String> command = new ArrayList<>();
         command.add("codex");
@@ -96,11 +105,21 @@ public final class CodexAgentHandler extends AiAgentTypeHandler {
         FilePath tempDir = AiAgentTempFiles.tempRoot(workspace);
         FilePath homeDir = tempDir.child("ai-agent-codex-home-" + System.nanoTime());
         FilePath codexDir = homeDir.child(".codex");
-        codexDir.mkdirs();
-        codexDir.child("config.toml").write(Util.fixNull(customConfigToml), "UTF-8");
+        try {
+            codexDir.mkdirs();
+            codexDir.child("config.toml").write(Util.fixNull(customConfigToml), "UTF-8");
+        } catch (IOException | InterruptedException e) {
+            try {
+                homeDir.deleteRecursive();
+            } catch (IOException | InterruptedException cleanupFailure) {
+                e.addSuppressed(cleanupFailure);
+            }
+            throw e;
+        }
         String codexHome = homeDir.getRemote();
         customization.putEnvironment("HOME", codexHome);
         customization.putEnvironment("USERPROFILE", codexHome);
+        customization.putEnvironment("CODEX_HOME", codexDir.getRemote());
         customization.addCleanupAction(homeDir::deleteRecursive);
         listener.getLogger()
                 .println("[ai-agent] Using job-scoped Codex config.toml from agent configuration.");

--- a/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler.java
@@ -105,9 +105,14 @@ public final class CodexAgentHandler extends AiAgentTypeHandler {
         FilePath tempDir = AiAgentTempFiles.tempRoot(workspace);
         FilePath homeDir = tempDir.child("ai-agent-codex-home-" + System.nanoTime());
         FilePath codexDir = homeDir.child(".codex");
+        FilePath configFile = codexDir.child("config.toml");
         try {
+            homeDir.mkdirs();
+            homeDir.chmod(0700);
             codexDir.mkdirs();
-            codexDir.child("config.toml").write(Util.fixNull(customConfigToml), "UTF-8");
+            codexDir.chmod(0700);
+            configFile.write(Util.fixNull(customConfigToml), "UTF-8");
+            configFile.chmod(0600);
         } catch (IOException | InterruptedException e) {
             try {
                 homeDir.deleteRecursive();

--- a/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexStatsExtractor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexStatsExtractor.java
@@ -25,6 +25,9 @@ public final class CodexStatsExtractor implements AiAgentStatsExtractor {
             JSONObject usage = json.optJSONObject("usage");
             if (usage != null) {
                 stats.accumulateUsage(usage);
+                long input = usage.optLong("input_tokens", 0);
+                long output = usage.optLong("output_tokens", 0);
+                stats.addTotalTokens(AgentUsageStats.saturatedAdd(input, output));
             }
             return true;
         }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/geminicli/GeminiCliAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/geminicli/GeminiCliAgentHandler.java
@@ -41,9 +41,6 @@ public final class GeminiCliAgentHandler extends AiAgentTypeHandler {
         command.add("stream-json");
         if (config.isYoloMode()) {
             command.add("--yolo");
-        } else if (config.isRequireApprovals()) {
-            command.add("--approval-mode");
-            command.add("default");
         }
         String model = Util.fixEmptyAndTrim(config.getModel());
         if (model != null) {

--- a/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeAgentHandler.java
@@ -34,6 +34,11 @@ public final class OpenCodeAgentHandler extends AiAgentTypeHandler {
     }
 
     @Override
+    public boolean supportsManualApprovals() {
+        return true;
+    }
+
+    @Override
     public List<String> buildDefaultCommand(AiAgentConfiguration config, String prompt) {
         List<String> command = new ArrayList<>();
         command.add("opencode");

--- a/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeLogFormat.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeLogFormat.java
@@ -84,7 +84,7 @@ public final class OpenCodeLogFormat implements AiAgentLogFormat {
                     lineNumber, "user", "User", text, rawDetails);
         }
         if ("agent_thought_chunk".equals(updateType)) {
-            return AiAgentLogParser.ParsedLine.thinking(lineNumber, text, rawDetails);
+            return AiAgentLogParser.ParsedLine.thinking(lineNumber, text, rawDetails, true);
         }
         if ("tool_call".equals(updateType)) {
             return classifyAcpToolCall(lineNumber, update, rawDetails);

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-  Adds a reusable <strong>Run AI Agent</strong> build step for running Claude Code, Codex CLI, Cursor Agent, OpenCode, and Gemini CLI with interactive conversation logs and approval gates.
+  Adds a reusable <strong>Run AI Agent</strong> build step for running Claude Code, Codex CLI, Cursor Agent, OpenCode, and Gemini CLI with interactive conversation logs and OpenCode approval gates.
 </div>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-model.html
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-model.html
@@ -1,5 +1,5 @@
 <div>
   The model identifier to pass to the AI agent (for example
-  <code>claude-sonnet-4</code>, <code>o3</code>, <code>gemini-2.5-pro</code>).
+  <code>claude-sonnet-4</code>, <code>gpt-5.5</code>, <code>gemini-2.5-pro</code>).
   Leave empty to use the agent's default model.
 </div>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-requireApprovals.html
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-requireApprovals.html
@@ -1,5 +1,5 @@
 <div>
-  When enabled, the build pauses each time the agent requests a tool call
-  (shell command, file edit, etc.) and waits for manual approval or denial
-  through the Jenkins UI before continuing.
+  OpenCode only. The build pauses each time OpenCode requests a tool call and
+  waits for manual approval or denial through the Jenkins UI before continuing.
+  Other built-in agents and command overrides reject this setting before launch.
 </div>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/conversation.jelly
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/conversation.jelly
@@ -2,12 +2,14 @@
 <j:jelly xmlns:j="jelly:core"
          xmlns:st="jelly:stapler"
          xmlns:l="/lib/layout">
-  <script src="${resURL}/plugin/ai-agent/js/bundles/marked.umd.js"></script>
-  <st:adjunct includes="io.jenkins.plugins.aiagentjob.AiAgentRunAction.summary_resources" />
-
   <j:set var="selectedId" value="${it.selectedInvocationId}" />
 
   <l:layout permission="${it.run.parent.READ}" title="AI Agent Conversation">
+    <l:header>
+      <script src="${resURL}/plugin/ai-agent/js/bundles/marked.umd.js"></script>
+      <st:adjunct includes="io.jenkins.plugins.aiagentjob.AiAgentRunAction.summary_resources" />
+    </l:header>
+
     <st:include page="sidepanel.jelly" it="${it.run}"/>
     <l:main-panel>
       <l:app-bar title="AI Agent Conversation" subtitle="#${selectedId}">

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary_resources.js
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary_resources.js
@@ -1,4 +1,34 @@
 (function () {
+  function buildApprovalUrl(url, id, reason) {
+    const params = new URLSearchParams();
+    params.append('id', id);
+    if (reason != null && reason !== '') {
+      params.append('reason', reason);
+    }
+    return url + (url.indexOf('?') >= 0 ? '&' : '?') + params.toString();
+  }
+
+  function isSafeUrl(value, allowMailto, baseUrl) {
+    if (!value) {
+      return false;
+    }
+    try {
+      const base = baseUrl
+        || (typeof window !== 'undefined' ? window.location.href : 'https://localhost/');
+      const parsed = new URL(value, base);
+      return parsed.protocol === 'http:'
+        || parsed.protocol === 'https:'
+        || (allowMailto && parsed.protocol === 'mailto:');
+    } catch (e) {
+      return false;
+    }
+  }
+
+  if (typeof module === 'object' && module.exports && typeof document === 'undefined') {
+    module.exports = { buildApprovalUrl: buildApprovalUrl, isSafeUrl: isSafeUrl };
+    return;
+  }
+
   function esc(text) {
     const div = document.createElement('div');
     div.appendChild(document.createTextNode(text || ''));
@@ -86,20 +116,6 @@
       out = out.substring(0, out.length - 5);
     }
     return out;
-  }
-
-  function isSafeUrl(value, allowMailto) {
-    if (!value) {
-      return false;
-    }
-    try {
-      const parsed = new URL(value, window.location.href);
-      return parsed.protocol === 'http:'
-        || parsed.protocol === 'https:'
-        || (allowMailto && parsed.protocol === 'mailto:');
-    } catch (e) {
-      return false;
-    }
   }
 
   function sanitizeHtml(html) {
@@ -315,18 +331,12 @@
     const buttons = card.querySelectorAll('button');
     buttons.forEach(function(b) { b.disabled = true; });
 
-    const params = new URLSearchParams();
-    params.append('id', id);
-    if (reason != null && reason !== '') {
-      params.append('reason', reason);
-    }
-
     const headers = { 'Accept': 'application/json' };
     if (crumbRequestField && crumbValue) {
       headers[crumbRequestField] = crumbValue;
     }
 
-    fetch(url + '?' + params.toString(), {
+    fetch(buildApprovalUrl(url, id, reason), {
       method: 'POST',
       credentials: 'same-origin',
       headers: headers

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary_resources.js
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary_resources.js
@@ -24,11 +24,6 @@
     }
   }
 
-  if (typeof module === 'object' && module.exports && typeof document === 'undefined') {
-    module.exports = { buildApprovalUrl: buildApprovalUrl, isSafeUrl: isSafeUrl };
-    return;
-  }
-
   function esc(text) {
     const div = document.createElement('div');
     div.appendChild(document.createTextNode(text || ''));
@@ -165,7 +160,9 @@
         }
       }
     }
-    return template.innerHTML;
+    const output = document.createElement('div');
+    output.appendChild(template.content.cloneNode(true));
+    return output.innerHTML;
   }
 
   function mdToHtml(text) {
@@ -533,6 +530,17 @@
         });
       }
     }
+  }
+
+  if (typeof module === 'object' && module.exports) {
+    module.exports = {
+      appendDelta: appendDelta,
+      buildApprovalUrl: buildApprovalUrl,
+      isSafeUrl: isSafeUrl,
+      renderEvent: renderEvent,
+      sanitizeHtml: sanitizeHtml
+    };
+    return;
   }
 
   if (document.readyState === 'loading') {

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary_resources.js
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary_resources.js
@@ -5,6 +5,10 @@
     return div.innerHTML;
   }
 
+  function escAttr(text) {
+    return esc(text).replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+  }
+
   function inlineMd(text) {
     let html = esc(text);
     html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
@@ -84,17 +88,84 @@
     return out;
   }
 
+  function isSafeUrl(value, allowMailto) {
+    if (!value) {
+      return false;
+    }
+    try {
+      const parsed = new URL(value, window.location.href);
+      return parsed.protocol === 'http:'
+        || parsed.protocol === 'https:'
+        || (allowMailto && parsed.protocol === 'mailto:');
+    } catch (e) {
+      return false;
+    }
+  }
+
+  function sanitizeHtml(html) {
+    const allowedAttributes = {
+      A: ['href', 'title'],
+      CODE: ['class'],
+      IMG: ['src', 'alt', 'title'],
+      OL: ['start'],
+      TD: ['align', 'colspan', 'rowspan'],
+      TH: ['align', 'colspan', 'rowspan']
+    };
+    const allowedTags = new Set([
+      'A', 'BLOCKQUOTE', 'BR', 'CODE', 'DEL', 'EM', 'H1', 'H2', 'H3', 'H4',
+      'H5', 'H6', 'HR', 'IMG', 'LI', 'OL', 'P', 'PRE', 'STRONG', 'TABLE',
+      'TBODY', 'TD', 'TH', 'THEAD', 'TR', 'UL'
+    ]);
+    const template = document.createElement('template');
+    template.innerHTML = html;
+    const elements = template.content.querySelectorAll('*');
+    for (let i = 0; i < elements.length; i++) {
+      const element = elements[i];
+      if (!allowedTags.has(element.tagName)) {
+        if (element.parentNode) {
+          element.parentNode.replaceChild(
+            document.createTextNode(element.textContent || ''),
+            element
+          );
+        }
+        continue;
+      }
+
+      const allowed = allowedAttributes[element.tagName] || [];
+      const attributes = Array.prototype.slice.call(element.attributes);
+      for (let j = 0; j < attributes.length; j++) {
+        if (allowed.indexOf(attributes[j].name.toLowerCase()) === -1) {
+          element.removeAttribute(attributes[j].name);
+        }
+      }
+
+      if (element.tagName === 'A' && element.hasAttribute('href')) {
+        if (!isSafeUrl(element.getAttribute('href'), true)) {
+          element.removeAttribute('href');
+        }
+      } else if (element.tagName === 'IMG' && element.hasAttribute('src')) {
+        if (!isSafeUrl(element.getAttribute('src'), false)) {
+          element.removeAttribute('src');
+        }
+      }
+    }
+    return template.innerHTML;
+  }
+
   function mdToHtml(text) {
+    let html;
     if (window.marked && typeof window.marked.parse === 'function') {
-      return window.marked.parse(esc(text || ''), {
+      html = window.marked.parse(esc(text || ''), {
         async: false,
         breaks: true,
         gfm: true,
         headerIds: false,
         mangle: false
       });
+    } else {
+      html = mdToHtmlFallback(text);
     }
-    return mdToHtmlFallback(text);
+    return sanitizeHtml(html);
   }
 
   function renderMarkdownNodes(root) {
@@ -116,12 +187,12 @@
 
   function renderEvent(ev) {
     const cat = ev.category;
-    let html = '<div class="ai-ev" data-category="' + esc(cat) + '">';
+    let html = '<div class="ai-ev" data-category="' + escAttr(cat) + '">';
 
     if (cat === 'assistant' || cat === 'user' || cat === 'result' || cat === 'error') {
-      html += '<span class="ai-badge ai-badge-' + cat + '">' + esc(ev.label) + '</span>';
+      html += '<span class="ai-badge ai-badge-' + escAttr(cat) + '">' + esc(ev.label) + '</span>';
       const contentClasses = 'ai-msg-content' + (cat === 'assistant' ? ' ai-msg-content-assistant' : '');
-      html += '<div class="' + contentClasses + '" data-md="' + esc(ev.content || '') + '">' + mdToHtml(ev.content) + '</div>';
+      html += '<div class="' + contentClasses + '" data-md="' + escAttr(ev.content || '') + '">' + mdToHtml(ev.content) + '</div>';
     } else if (cat === 'tool_call') {
       html += '<details>';
       html += '<summary class="ai-tool-header ai-details-summary">';
@@ -157,12 +228,12 @@
       html += '<summary class="ai-details-summary">';
       html += '<span class="ai-badge ai-badge-thinking">Thinking</span>';
       html += '</summary>';
-      html += '<div class="ai-thinking-text">' + esc(ev.content) + '</div>';
+      html += '<div class="ai-thinking-text" data-content="' + escAttr(ev.content || '') + '">' + esc(ev.content) + '</div>';
       html += '</details>';
     } else {
       html += '<details>';
       html += '<summary class="ai-details-summary">';
-      html += '<span class="ai-badge ai-badge-' + cat + '">' + esc(ev.label) + '</span>';
+      html += '<span class="ai-badge ai-badge-' + escAttr(cat) + '">' + esc(ev.label) + '</span>';
       html += '<span class="ai-system-text">' + excerpt(ev.content, 100) + '</span>';
       html += '</summary>';
       html += '<div class="ai-system-text ai-system-detail">' + esc(ev.content) + '</div>';
@@ -173,19 +244,31 @@
     return html;
   }
 
-  function appendAssistantDelta(container, ev) {
-    if (!ev || !ev.delta || ev.category !== 'assistant') {
+  function appendDelta(container, ev) {
+    if (!ev || !ev.delta || (ev.category !== 'assistant' && ev.category !== 'thinking')) {
       return false;
     }
-    const assistantBodies = container.querySelectorAll('.ai-ev[data-category="assistant"] .ai-msg-content-assistant');
-    if (!assistantBodies || assistantBodies.length === 0) {
+    const previousEvent = container.lastElementChild;
+    if (!previousEvent || previousEvent.getAttribute('data-category') !== ev.category) {
       return false;
     }
-    const last = assistantBodies[assistantBodies.length - 1];
-    const previousMd = last.getAttribute('data-md') || '';
-    const mergedMd = previousMd + (ev.content || '');
-    last.setAttribute('data-md', mergedMd);
-    last.innerHTML = mdToHtml(mergedMd);
+    const selector = ev.category === 'assistant'
+      ? '.ai-msg-content-assistant'
+      : '.ai-thinking-text';
+    const last = previousEvent.querySelector(selector);
+    if (!last) {
+      return false;
+    }
+    if (ev.category === 'assistant') {
+      const previousMd = last.getAttribute('data-md') || '';
+      const mergedMd = previousMd + (ev.content || '');
+      last.setAttribute('data-md', mergedMd);
+      last.innerHTML = mdToHtml(mergedMd);
+    } else {
+      const mergedText = (last.getAttribute('data-content') || '') + (ev.content || '');
+      last.setAttribute('data-content', mergedText);
+      last.textContent = mergedText;
+    }
     return true;
   }
 
@@ -200,15 +283,15 @@
     let html = '';
     for (let i = 0; i < approvals.length; i++) {
       const approval = approvals[i];
-      html += '<div class="ai-approval-card" data-approval-id="' + esc(approval.id) + '">';
+      html += '<div class="ai-approval-card" data-approval-id="' + escAttr(approval.id) + '">';
       html += '<strong>Approval required:</strong> ' + esc(approval.toolName);
       html += ' <span class="ai-approval-summary">- ' + esc(approval.inputSummary) + '</span>';
       html += '<div class="actions">';
       html += '<button type="button" class="jenkins-button jenkins-button--primary ai-approve-btn" '
-            + 'data-url="' + esc(approveUrl) + '" data-id="' + esc(approval.id) + '">Approve</button>';
+            + 'data-url="' + escAttr(approveUrl) + '" data-id="' + escAttr(approval.id) + '">Approve</button>';
       html += '<input type="text" placeholder="reason (optional)" class="ai-approval-reason ai-deny-reason-input jenkins-input" />';
       html += '<button type="button" class="jenkins-button jenkins-button--primary ai-deny-btn" '
-            + 'data-url="' + esc(denyUrl) + '" data-id="' + esc(approval.id) + '">Deny</button>';
+            + 'data-url="' + escAttr(denyUrl) + '" data-id="' + escAttr(approval.id) + '">Deny</button>';
       html += '</div></div>';
     }
     container.innerHTML = html;
@@ -364,13 +447,19 @@
         if (events.length > 0) {
           let html = '';
           for (let i = 0; i < events.length; i++) {
-            if (appendAssistantDelta(container, events[i])) {
+            if (events[i].delta && html) {
+              container.insertAdjacentHTML('beforeend', html);
+              html = '';
+            }
+            if (appendDelta(container, events[i])) {
               continue;
             }
             html += renderEvent(events[i]);
             eventCount++;
           }
-          container.insertAdjacentHTML('beforeend', html);
+          if (html) {
+            container.insertAdjacentHTML('beforeend', html);
+          }
           if (shouldScroll) {
             container.scrollTop = container.scrollHeight;
           }
@@ -423,16 +512,16 @@
     const details = document.querySelectorAll('.ai-invocation-details');
     if (details.length > 0) {
       const conv = details[0].querySelector('.ai-conv');
-        if (conv) {
-            conv.classList.remove("jenkins-hidden");
-        }
-        for (let j = 0; j < details.length; j++) {
-            const title = details[j].querySelector('.ai-invocation-title');
-            const conversation = details[0].querySelector('.ai-conv');
-            title.addEventListener('click', function (event) {
-                conversation.classList.toggle('jenkins-hidden');
-             });
-        }
+      if (conv) {
+        conv.classList.remove('jenkins-hidden');
+      }
+      for (let j = 0; j < details.length; j++) {
+        const title = details[j].querySelector('.ai-invocation-title');
+        const conversation = details[j].querySelector('.ai-conv');
+        title.addEventListener('click', function () {
+          conversation.classList.toggle('jenkins-hidden');
+        });
+      }
     }
   }
 

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AgentUsageStatsTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AgentUsageStatsTest.java
@@ -100,6 +100,7 @@ class AgentUsageStatsTest {
         assertEquals(108, stats.getOutputTokens());
         assertEquals(30976, stats.getCacheReadTokens());
         assertEquals(49, stats.getReasoningTokens());
+        assertEquals(42689, stats.getTotalTokens());
     }
 
     @Test
@@ -107,6 +108,19 @@ class AgentUsageStatsTest {
         AgentUsageStats stats = parseStats("stats-codex.jsonl", CodexStatsExtractor.INSTANCE);
         assertEquals("", stats.getCostDisplay());
         assertEquals("", stats.getDurationDisplay());
+    }
+
+    @Test
+    void codex_negativeUsageDoesNotReduceTotal() {
+        AgentUsageStats stats = new AgentUsageStats();
+        stats.extractFrom(
+                JSONObject.fromObject(
+                        "{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":-7,\"output_tokens\":5}}"),
+                CodexStatsExtractor.INSTANCE);
+
+        assertEquals(0, stats.getInputTokens());
+        assertEquals(5, stats.getOutputTokens());
+        assertEquals(5, stats.getTotalTokens());
     }
 
     // ======================== OpenCode ========================
@@ -138,6 +152,24 @@ class AgentUsageStatsTest {
         assertEquals(9000 + 7000, stats.getCacheWriteTokens());
         assertEquals(10000 + 8000, stats.getTotalTokens());
         assertEquals(0.005 + 0.003, stats.getCostUsd(), 0.0001);
+    }
+
+    @Test
+    void openCode_tokenAggregationSaturatesInsteadOfOverflowing() {
+        AgentUsageStats stats = new AgentUsageStats();
+        stats.extractFrom(
+                JSONObject.fromObject(
+                        "{\"type\":\"step_finish\",\"part\":{\"tokens\":{\"input\":"
+                                + Long.MAX_VALUE
+                                + "}}}"),
+                OpenCodeStatsExtractor.INSTANCE);
+        stats.extractFrom(
+                JSONObject.fromObject(
+                        "{\"type\":\"step_finish\",\"part\":{\"tokens\":{\"input\":1}}}"),
+                OpenCodeStatsExtractor.INSTANCE);
+
+        assertEquals(Long.MAX_VALUE, stats.getInputTokens());
+        assertTrue(stats.hasData());
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
@@ -1,10 +1,12 @@
 package io.jenkins.plugins.aiagentjob;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import hudson.FilePath;
+import hudson.model.Executor;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersAction;
@@ -12,11 +14,14 @@ import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
 import hudson.model.StringParameterDefinition;
 import hudson.model.StringParameterValue;
+import hudson.model.TaskListener;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.WorkspaceList;
 
 import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeAgentHandler;
+import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeLogFormat;
+import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeStatsExtractor;
 import io.jenkins.plugins.aiagentjob.codex.CodexAgentHandler;
 import io.jenkins.plugins.aiagentjob.opencode.OpenCodeAgentHandler;
 
@@ -27,13 +32,55 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @WithJenkins
 class AiAgentBuildExecutionTest {
+
+    public static final class FailingAfterPrepareAgent extends AiAgentTypeHandler {
+        private static final String TEMP_DIR_NAME = "ai-agent-cleanup-test";
+
+        @Override
+        public String getId() {
+            return "FAILING_AFTER_PREPARE";
+        }
+
+        @Override
+        public String getDefaultApiKeyEnvVar() {
+            return "TEST_API_KEY";
+        }
+
+        @Override
+        public List<String> buildDefaultCommand(AiAgentConfiguration config, String prompt) {
+            throw new IllegalStateException("failure after prepare");
+        }
+
+        @Override
+        public AiAgentExecutionCustomization prepareExecution(
+                AiAgentConfiguration config, FilePath workspace, TaskListener listener)
+                throws IOException, InterruptedException {
+            FilePath tempDir = AiAgentTempFiles.tempRoot(workspace).child(TEMP_DIR_NAME);
+            tempDir.mkdirs();
+            AiAgentExecutionCustomization customization = AiAgentExecutionCustomization.empty();
+            customization.addCleanupAction(tempDir::deleteRecursive);
+            return customization;
+        }
+
+        @Override
+        public AiAgentLogFormat getLogFormat() {
+            return ClaudeCodeLogFormat.INSTANCE;
+        }
+
+        @Override
+        public AiAgentStatsExtractor getStatsExtractor() {
+            return ClaudeCodeStatsExtractor.INSTANCE;
+        }
+    }
 
     private FreeStyleProject newProject(
             JenkinsRule jenkins, String name, java.util.function.Consumer<AiAgentBuilder> cfg)
@@ -119,6 +166,28 @@ class AiAgentBuildExecutionTest {
 
     @Test
     @EnabledOnOs(OS.LINUX)
+    void setupFailureAfterPrepare_runsAgentCleanup(JenkinsRule jenkins) throws Exception {
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-prepare-cleanup",
+                        b -> {
+                            b.setAgent(new FailingAfterPrepareAgent());
+                            b.setPrompt("hello");
+                        });
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        jenkins.assertBuildStatus(Result.FAILURE, build);
+        FilePath workspace = build.getWorkspace();
+        assertNotNull(workspace);
+        assertFalse(
+                AiAgentTempFiles.tempRoot(workspace)
+                        .child(FailingAfterPrepareAgent.TEMP_DIR_NAME)
+                        .exists());
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
     void setupScript_emptyIsSkipped(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project =
                 newProject(
@@ -198,10 +267,12 @@ class AiAgentBuildExecutionTest {
                             codex.setCustomConfigToml("[mcp_servers.demo]\ncommand = \"npx\"");
                             b.setAgent(codex);
                             b.setPrompt("hello");
+                            b.setEnvironmentVariables("CODEX_HOME=/tmp/shared-codex-home");
                             b.setCommandOverride(
-                                    "cfg=\"$USERPROFILE/.codex/config.toml\"; "
+                                    "cfg=\"$CODEX_HOME/config.toml\"; "
                                             + "if test -f \"$cfg\"; then echo CODEX_CONFIG_FOUND; sed -n '1,200p' \"$cfg\"; "
-                                            + "else echo CODEX_CONFIG_MISSING home=$HOME userprofile=$USERPROFILE; fi; "
+                                            + "else echo CODEX_CONFIG_MISSING home=$HOME codex_home=$CODEX_HOME; fi; "
+                                            + "echo CODEX_HOME=$CODEX_HOME; "
                                             + "echo '{\"type\":\"assistant\",\"message\":\"done\"}'");
                             b.setFailOnAgentError(true);
                         });
@@ -218,6 +289,9 @@ class AiAgentBuildExecutionTest {
                 "Codex config should be written to run-scoped home");
         assertTrue(log.contains("command = \"npx\""), "Codex config should preserve TOML content");
         assertFalse(log.contains("CODEX_CONFIG_MISSING"), "Codex config should not be missing");
+        assertFalse(
+                log.contains("CODEX_HOME=/tmp/shared-codex-home"),
+                "Job-scoped config should override inherited CODEX_HOME");
     }
 
     @Test
@@ -239,12 +313,132 @@ class AiAgentBuildExecutionTest {
                                             + "echo '{\"type\":\"assistant\",\"message\":\"done\"}'");
                         });
 
-        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0);
+        assertNotNull(future);
+        FreeStyleBuild build = future.get(5, TimeUnit.SECONDS);
         jenkins.assertBuildStatus(Result.FAILURE, build);
 
         AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
         assertNotNull(action);
         assertTrue(action.getEvents().stream().anyMatch(e -> "tool_call".equals(e.getCategory())));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void abortWhileApprovalIsPendingCompletesPromptly(JenkinsRule jenkins) throws Exception {
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-abort-approval",
+                        b -> {
+                            b.setAgent(new ClaudeCodeAgentHandler());
+                            b.setPrompt("needs approval");
+                            b.setRequireApprovals(true);
+                            b.setApprovalTimeoutSeconds(60);
+                            b.setCommandOverride(
+                                    "echo '{\"type\":\"tool_call\",\"tool_name\":\"bash\",\"tool_call_id\":\"call-1\",\"text\":\"ls\"}'; sleep 60");
+                        });
+
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0);
+        assertNotNull(future);
+        FreeStyleBuild runningBuild = future.waitForStart();
+        waitForPendingApproval(jenkins, runningBuild, future);
+
+        Executor executor = runningBuild.getExecutor();
+        assertNotNull(executor);
+        long started = System.nanoTime();
+        executor.interrupt(Result.ABORTED);
+
+        FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
+        assertEquals(Result.ABORTED, build.getResult());
+        assertTrue(
+                System.nanoTime() - started < TimeUnit.SECONDS.toNanos(10),
+                "Aborting should not wait for approval timeout");
+        assertTrue(
+                build.getAction(AiAgentRunAction.class).getPendingApprovals().isEmpty(),
+                "Aborting should remove pending approval cards");
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void codexCommandOverrideCannotBypassApprovalValidation(JenkinsRule jenkins) throws Exception {
+        File marker = new File(jenkins.jenkins.getRootDir(), "codex-override-ran");
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-codex-approval-override",
+                        b -> {
+                            b.setAgent(new CodexAgentHandler());
+                            b.setPrompt("test");
+                            b.setRequireApprovals(true);
+                            b.setCommandOverride("touch '" + marker.getAbsolutePath() + "'");
+                        });
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        jenkins.assertBuildStatus(Result.FAILURE, build);
+        assertFalse(marker.exists(), "Rejected Codex configuration must not launch override");
+        assertTrue(jenkins.getLog(build).contains("does not expose"));
+    }
+
+    @Test
+    void windowsCommandUsesCmdWithoutFlatteningLaunchMode() {
+        List<String> command =
+                AiAgentExecutor.buildWindowsCommand(
+                        List.of("codex", "exec", "prompt with spaces", "100% literal"));
+
+        assertEquals("cmd.exe", command.get(0));
+        assertEquals("/C", command.get(1));
+        String commandLine = String.join(" ", command.subList(2, command.size()));
+        assertTrue(commandLine.contains("prompt with spaces"));
+        assertTrue(commandLine.contains("100% literal"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void claudeContentArray_waitsForEveryToolApproval(JenkinsRule jenkins) throws Exception {
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-parallel-approvals",
+                        b -> {
+                            b.setAgent(new ClaudeCodeAgentHandler());
+                            b.setPrompt("needs two approvals");
+                            b.setRequireApprovals(true);
+                            b.setApprovalTimeoutSeconds(30);
+                            b.setFailOnAgentError(true);
+                            b.setCommandOverride(
+                                    "echo '{\"type\":\"assistant\",\"message\":{\"content\":["
+                                            + "{\"type\":\"tool_use\",\"id\":\"call-1\",\"name\":\"Bash\",\"input\":{\"command\":\"pwd\"}},"
+                                            + "{\"type\":\"tool_use\",\"id\":\"call-2\",\"name\":\"Read\",\"input\":{\"file_path\":\"README.md\"}}]}}'");
+                        });
+
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0);
+        assertNotNull(future);
+        FreeStyleBuild runningBuild = future.waitForStart();
+        ExecutionRegistry.PendingApproval first =
+                waitForPendingApproval(jenkins, runningBuild, future);
+        assertEquals("call-1", first.getToolCallId());
+
+        AiAgentRunAction action = runningBuild.getAction(AiAgentRunAction.class);
+        assertNotNull(action);
+        ExecutionRegistry.LiveExecution liveExecution =
+                ExecutionRegistry.get(runningBuild, action.getLatestInvocationId());
+        assertNotNull(liveExecution);
+        assertTrue(liveExecution.approve(first.getId()));
+
+        ExecutionRegistry.PendingApproval second =
+                waitForPendingApproval(jenkins, runningBuild, future);
+        assertEquals("call-2", second.getToolCallId());
+        assertTrue(liveExecution.approve(second.getId()));
+
+        FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
+        jenkins.assertBuildStatusSuccess(build);
+        assertEquals(
+                2,
+                action.getEvents().stream()
+                        .filter(event -> "tool_call".equals(event.getCategory()))
+                        .count());
     }
 
     @Test
@@ -338,12 +532,12 @@ class AiAgentBuildExecutionTest {
             if (future.isDone()) {
                 FreeStyleBuild completed = future.get();
                 throw new AssertionError(
-                        "OpenCode ACP build completed before requesting approval:\n"
+                        "AI agent build completed before requesting approval:\n"
                                 + jenkins.getLog(completed));
             }
             Thread.sleep(50);
         }
-        throw new AssertionError("OpenCode ACP approval request did not reach Jenkins.");
+        throw new AssertionError("AI agent approval request did not reach Jenkins.");
     }
 
     @Test
@@ -355,7 +549,7 @@ class AiAgentBuildExecutionTest {
                         "ai-build-step-env",
                         b -> {
                             b.setAgent(new ClaudeCodeAgentHandler());
-                            b.setPrompt("hello");
+                            b.setPrompt("prompt-${SURROUNDING_VAR}");
                             b.setCommandOverride(
                                     "echo \"{\\\"type\\\":\\\"assistant\\\",\\\"message\\\":\\\"step=$SURROUNDING_VAR\\\"}\"");
                             b.setFailOnAgentError(true);
@@ -379,6 +573,9 @@ class AiAgentBuildExecutionTest {
         assertTrue(
                 rawLog.contains("step=from-parameter"),
                 "Command override should inherit step-scoped env vars");
+        AiAgentRunAction.InvocationRecord invocation = action.getInvocations().get(0);
+        assertEquals("", invocation.getPrompt());
+        assertEquals("", invocation.getCommandLine());
     }
 
     @Test
@@ -427,8 +624,8 @@ class AiAgentBuildExecutionTest {
                             b.setAgent(codex);
                             b.setPrompt("hello");
                             b.setCommandOverride(
-                                    "cfg=\"$HOME/.codex/config.toml\"; "
-                                            + "echo \"{\\\"type\\\":\\\"assistant\\\",\\\"message\\\":\\\"cfg=$cfg home=$HOME\\\"}\"");
+                                    "cfg=\"$CODEX_HOME/config.toml\"; "
+                                            + "echo \"{\\\"type\\\":\\\"assistant\\\",\\\"message\\\":\\\"cfg=$cfg home=$HOME codex_home=$CODEX_HOME\\\"}\"");
                             b.setFailOnAgentError(true);
                         });
         project.setAssignedNode(agent);

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
@@ -23,6 +23,7 @@ import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeAgentHandler;
 import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeLogFormat;
 import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeStatsExtractor;
 import io.jenkins.plugins.aiagentjob.codex.CodexAgentHandler;
+import io.jenkins.plugins.aiagentjob.cursor.CursorAgentHandler;
 import io.jenkins.plugins.aiagentjob.opencode.OpenCodeAgentHandler;
 
 import org.junit.jupiter.api.Test;
@@ -272,6 +273,9 @@ class AiAgentBuildExecutionTest {
                                     "cfg=\"$CODEX_HOME/config.toml\"; "
                                             + "if test -f \"$cfg\"; then echo CODEX_CONFIG_FOUND; sed -n '1,200p' \"$cfg\"; "
                                             + "else echo CODEX_CONFIG_MISSING home=$HOME codex_home=$CODEX_HOME; fi; "
+                                            + "echo CODEX_HOME_MODE=$(stat -c %a \"$HOME\"); "
+                                            + "echo CODEX_DIR_MODE=$(stat -c %a \"$CODEX_HOME\"); "
+                                            + "echo CODEX_CONFIG_MODE=$(stat -c %a \"$cfg\"); "
                                             + "echo CODEX_HOME=$CODEX_HOME; "
                                             + "echo '{\"type\":\"assistant\",\"message\":\"done\"}'");
                             b.setFailOnAgentError(true);
@@ -292,25 +296,28 @@ class AiAgentBuildExecutionTest {
         assertFalse(
                 log.contains("CODEX_HOME=/tmp/shared-codex-home"),
                 "Job-scoped config should override inherited CODEX_HOME");
+        assertTrue(log.contains("CODEX_HOME_MODE=700"), "Codex home should be owner-only");
+        assertTrue(
+                log.contains("CODEX_DIR_MODE=700"), "Codex config directory should be owner-only");
+        assertTrue(log.contains("CODEX_CONFIG_MODE=600"), "Codex config should be owner-only");
     }
 
     @Test
     @EnabledOnOs(OS.LINUX)
     void failsWhenApprovalTimesOut(JenkinsRule jenkins) throws Exception {
+        File fakeBin = installFakeOpenCode(jenkins, "fake-opencode-timeout-bin");
+        String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
         FreeStyleProject project =
                 newProject(
                         jenkins,
                         "ai-build-approval-timeout",
                         b -> {
-                            b.setAgent(new ClaudeCodeAgentHandler());
+                            b.setAgent(new OpenCodeAgentHandler());
                             b.setPrompt("needs approval");
                             b.setRequireApprovals(true);
                             b.setApprovalTimeoutSeconds(1);
                             b.setFailOnAgentError(true);
-                            b.setCommandOverride(
-                                    "echo '{\"type\":\"tool_call\",\"tool_name\":\"bash\",\"tool_call_id\":\"call-1\",\"text\":\"ls\"}'; "
-                                            + "sleep 2; "
-                                            + "echo '{\"type\":\"assistant\",\"message\":\"done\"}'");
+                            b.setEnvironmentVariables("PATH=" + path);
                         });
 
         QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0);
@@ -320,23 +327,25 @@ class AiAgentBuildExecutionTest {
 
         AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
         assertNotNull(action);
-        assertTrue(action.getEvents().stream().anyMatch(e -> "tool_call".equals(e.getCategory())));
+        assertTrue(jenkins.getLog(build).contains("approval timed out after 1s"));
+        assertTrue(action.getPendingApprovals().isEmpty());
     }
 
     @Test
     @EnabledOnOs(OS.LINUX)
     void abortWhileApprovalIsPendingCompletesPromptly(JenkinsRule jenkins) throws Exception {
+        File fakeBin = installFakeOpenCode(jenkins, "fake-opencode-abort-bin");
+        String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
         FreeStyleProject project =
                 newProject(
                         jenkins,
                         "ai-build-abort-approval",
                         b -> {
-                            b.setAgent(new ClaudeCodeAgentHandler());
+                            b.setAgent(new OpenCodeAgentHandler());
                             b.setPrompt("needs approval");
                             b.setRequireApprovals(true);
                             b.setApprovalTimeoutSeconds(60);
-                            b.setCommandOverride(
-                                    "echo '{\"type\":\"tool_call\",\"tool_name\":\"bash\",\"tool_call_id\":\"call-1\",\"text\":\"ls\"}'; sleep 60");
+                            b.setEnvironmentVariables("PATH=" + path);
                         });
 
         QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0);
@@ -357,6 +366,70 @@ class AiAgentBuildExecutionTest {
         assertTrue(
                 build.getAction(AiAgentRunAction.class).getPendingApprovals().isEmpty(),
                 "Aborting should remove pending approval cards");
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void abortWhileAcpWaitsForAgentOutputCompletesPromptly(JenkinsRule jenkins) throws Exception {
+        File fakeBin =
+                installExecutable(
+                        jenkins,
+                        "fake-opencode-blocked-output-bin",
+                        "opencode",
+                        """
+                        #!/bin/sh
+                        set -eu
+                        test "${1:-}" = "acp"
+                        IFS= read -r request
+                        printf '%s\n' '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":1,"agentCapabilities":{},"authMethods":[]}}'
+                        IFS= read -r request
+                        printf '%s\n' '{"jsonrpc":"2.0","id":2,"result":{"sessionId":"session-1","configOptions":[]}}'
+                        IFS= read -r request
+                        touch acp-prompt-started
+                        sleep 5
+                        printf '%s\n' '{"jsonrpc":"2.0","id":3,"result":{"stopReason":"end_turn"}}'
+                        """);
+        String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-abort-acp-output",
+                        b -> {
+                            b.setAgent(new OpenCodeAgentHandler());
+                            b.setPrompt("wait for output");
+                            b.setRequireApprovals(true);
+                            b.setEnvironmentVariables("PATH=" + path);
+                        });
+        DumbSlave agent = jenkins.createOnlineSlave();
+        project.setAssignedNode(agent);
+
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0);
+        assertNotNull(future);
+        FreeStyleBuild runningBuild = future.waitForStart();
+        FilePath workspace = null;
+        long workspaceDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (workspace == null && System.nanoTime() < workspaceDeadline) {
+            workspace = runningBuild.getWorkspace();
+            Thread.sleep(50);
+        }
+        assertNotNull(workspace);
+        long markerDeadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(10);
+        while (!workspace.child("acp-prompt-started").exists()
+                && System.nanoTime() < markerDeadline) {
+            Thread.sleep(50);
+        }
+        assertTrue(workspace.child("acp-prompt-started").exists());
+
+        Executor executor = runningBuild.getExecutor();
+        assertNotNull(executor);
+        long started = System.nanoTime();
+        executor.interrupt(Result.ABORTED);
+
+        FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
+        assertEquals(Result.ABORTED, build.getResult());
+        assertTrue(
+                System.nanoTime() - started < TimeUnit.SECONDS.toNanos(3),
+                "Aborting should terminate an ACP process blocked on output");
     }
 
     @Test
@@ -396,66 +469,136 @@ class AiAgentBuildExecutionTest {
 
     @Test
     @EnabledOnOs(OS.LINUX)
-    void claudeContentArray_waitsForEveryToolApproval(JenkinsRule jenkins) throws Exception {
+    void setupScriptDoesNotTraceGeneratedAgentCommand(JenkinsRule jenkins) throws Exception {
+        String sensitivePrompt = "sensitive-prompt-not-for-build-log";
+        File fakeBin =
+                installExecutable(
+                        jenkins,
+                        "fake-cursor-trace-bin",
+                        "agent",
+                        "#!/bin/sh\nprintf '%s\\n' '{\"type\":\"assistant\",\"message\":\"ok\"}'\n");
+        String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
         FreeStyleProject project =
                 newProject(
                         jenkins,
-                        "ai-build-parallel-approvals",
+                        "ai-build-no-command-trace",
                         b -> {
-                            b.setAgent(new ClaudeCodeAgentHandler());
-                            b.setPrompt("needs two approvals");
-                            b.setRequireApprovals(true);
-                            b.setApprovalTimeoutSeconds(30);
-                            b.setFailOnAgentError(true);
-                            b.setCommandOverride(
-                                    "echo '{\"type\":\"assistant\",\"message\":{\"content\":["
-                                            + "{\"type\":\"tool_use\",\"id\":\"call-1\",\"name\":\"Bash\",\"input\":{\"command\":\"pwd\"}},"
-                                            + "{\"type\":\"tool_use\",\"id\":\"call-2\",\"name\":\"Read\",\"input\":{\"file_path\":\"README.md\"}}]}}'");
+                            b.setAgent(new CursorAgentHandler());
+                            b.setPrompt(sensitivePrompt);
+                            b.setSetupScript("true");
+                            b.setEnvironmentVariables("PATH=" + path);
                         });
 
-        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0);
-        assertNotNull(future);
-        FreeStyleBuild runningBuild = future.waitForStart();
-        ExecutionRegistry.PendingApproval first =
-                waitForPendingApproval(jenkins, runningBuild, future);
-        assertEquals("call-1", first.getToolCallId());
-
-        AiAgentRunAction action = runningBuild.getAction(AiAgentRunAction.class);
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+        AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
         assertNotNull(action);
-        ExecutionRegistry.LiveExecution liveExecution =
-                ExecutionRegistry.get(runningBuild, action.getLatestInvocationId());
-        assertNotNull(liveExecution);
-        assertTrue(liveExecution.approve(first.getId()));
 
-        ExecutionRegistry.PendingApproval second =
-                waitForPendingApproval(jenkins, runningBuild, future);
-        assertEquals("call-2", second.getToolCallId());
-        assertTrue(liveExecution.approve(second.getId()));
+        assertFalse(jenkins.getLog(build).contains(sensitivePrompt));
+        assertFalse(Files.readString(action.getRawLogFile().toPath()).contains(sensitivePrompt));
+    }
 
-        FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void setupScriptDoesNotTraceSensitiveValues(JenkinsRule jenkins) throws Exception {
+        String sensitiveValue = "setup-secret-not-for-build-log";
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-no-setup-trace",
+                        b -> {
+                            b.setAgent(new ClaudeCodeAgentHandler());
+                            b.setSetupScript(
+                                    "export SETUP_SECRET='"
+                                            + sensitiveValue
+                                            + "'; test -n \"$SETUP_SECRET\"");
+                            b.setCommandOverride(
+                                    "echo '{\"type\":\"assistant\",\"message\":\"done\"}'");
+                        });
+
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+        AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
+        assertNotNull(action);
+
+        assertFalse(jenkins.getLog(build).contains(sensitiveValue));
+        assertFalse(Files.readString(action.getRawLogFile().toPath()).contains(sensitiveValue));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void expandsParameterizedModelAndReasoningEffortInDefaultCommand(JenkinsRule jenkins)
+            throws Exception {
+        File fakeBin =
+                installExecutable(
+                        jenkins,
+                        "fake-codex-args-bin",
+                        "codex",
+                        "#!/bin/sh\nprintf '%s\\n' \"$@\"\n");
+        String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-expanded-command-options",
+                        b -> {
+                            b.setAgent(new CodexAgentHandler());
+                            b.setPrompt("test");
+                            b.setModel("${MODEL_CHOICE}");
+                            b.setReasoningEffort("${EFFORT_CHOICE}");
+                            b.setSetupScript("true");
+                            b.setEnvironmentVariables("PATH=" + path);
+                        });
+        project.addProperty(
+                new ParametersDefinitionProperty(
+                        new StringParameterDefinition("MODEL_CHOICE", "gpt-5.5"),
+                        new StringParameterDefinition("EFFORT_CHOICE", "xhigh")));
+
+        FreeStyleBuild build =
+                project.scheduleBuild2(
+                                0,
+                                new ParametersAction(
+                                        new StringParameterValue("MODEL_CHOICE", "gpt-5.5"),
+                                        new StringParameterValue("EFFORT_CHOICE", "xhigh")))
+                        .get();
         jenkins.assertBuildStatusSuccess(build);
-        assertEquals(
-                2,
-                action.getEvents().stream()
-                        .filter(event -> "tool_call".equals(event.getCategory()))
-                        .count());
+        AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
+        assertNotNull(action);
+        String rawLog = Files.readString(action.getRawLogFile().toPath());
+
+        assertTrue(rawLog.contains("gpt-5.5"));
+        assertTrue(rawLog.contains("model_reasoning_effort=\"xhigh\""));
+        assertFalse(rawLog.contains("${MODEL_CHOICE}"));
+        assertFalse(rawLog.contains("${EFFORT_CHOICE}"));
+        assertEquals("gpt-5.5", action.getInvocationModel(action.getLatestInvocationId()));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void processLaunchFailureCompletesInvocationMetadata(JenkinsRule jenkins) throws Exception {
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-launch-failure-metadata",
+                        b -> {
+                            b.setAgent(new ClaudeCodeAgentHandler());
+                            b.setPrompt("test");
+                            b.setSetupScript("#!/definitely/missing/ai-agent-interpreter\ntrue");
+                            b.setCommandOverride("true");
+                        });
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        jenkins.assertBuildStatus(Result.FAILURE, build);
+        AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
+        assertNotNull(action);
+        int invocationId = action.getLatestInvocationId();
+
+        assertEquals(-1, action.getInvocationExitCode(invocationId));
+        assertFalse(action.getInvocationCompletedAt(invocationId).isEmpty());
     }
 
     @Test
     @EnabledOnOs(OS.LINUX)
     void openCodeAcp_waitsForJenkinsApprovalBeforeToolExecution(JenkinsRule jenkins)
             throws Exception {
-        File fakeBin = new File(jenkins.jenkins.getRootDir(), "fake-opencode-bin");
-        assertTrue(fakeBin.mkdirs());
-        File fakeOpenCode = new File(fakeBin, "opencode");
-        try (InputStream fixture =
-                getClass()
-                        .getResourceAsStream(
-                                "/io/jenkins/plugins/aiagentjob/fixtures/fake-opencode-acp.sh")) {
-            assertNotNull(fixture);
-            Files.copy(fixture, fakeOpenCode.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        }
-        assertTrue(fakeOpenCode.setExecutable(true));
+        File fakeBin = installFakeOpenCode(jenkins, "fake-opencode-bin");
 
         String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
         FreeStyleProject project =
@@ -589,7 +732,9 @@ class AiAgentBuildExecutionTest {
                         b -> {
                             b.setAgent(new ClaudeCodeAgentHandler());
                             b.setPrompt("hello");
-                            b.setSetupScript("echo SETUP_SCRIPT_PATH=$0");
+                            b.setSetupScript(
+                                    "echo SETUP_SCRIPT_PATH=$0; "
+                                            + "echo SETUP_SCRIPT_MODE=$(stat -c %a \"$0\")");
                             b.setCommandOverride(
                                     "echo '{\"type\":\"assistant\",\"message\":\"remote\"}'");
                             b.setFailOnAgentError(true);
@@ -606,6 +751,7 @@ class AiAgentBuildExecutionTest {
         assertTrue(
                 log.contains("SETUP_SCRIPT_PATH=" + tempRoot.getRemote()),
                 "Setup script should run from the agent temp area");
+        assertTrue(log.contains("SETUP_SCRIPT_MODE=700"), "Temp script should be owner-only");
     }
 
     @Test
@@ -647,5 +793,31 @@ class AiAgentBuildExecutionTest {
         assertTrue(
                 rawLog.contains("/.codex/config.toml"),
                 "Codex config path should resolve inside the run-scoped home");
+    }
+
+    private static File installFakeOpenCode(JenkinsRule jenkins, String directoryName)
+            throws Exception {
+        File fakeBin = new File(jenkins.jenkins.getRootDir(), directoryName);
+        assertTrue(fakeBin.mkdirs());
+        File fakeOpenCode = new File(fakeBin, "opencode");
+        try (InputStream fixture =
+                AiAgentBuildExecutionTest.class.getResourceAsStream(
+                        "/io/jenkins/plugins/aiagentjob/fixtures/fake-opencode-acp.sh")) {
+            assertNotNull(fixture);
+            Files.copy(fixture, fakeOpenCode.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        }
+        assertTrue(fakeOpenCode.setExecutable(true));
+        return fakeBin;
+    }
+
+    private static File installExecutable(
+            JenkinsRule jenkins, String directoryName, String executableName, String content)
+            throws Exception {
+        File fakeBin = new File(jenkins.jenkins.getRootDir(), directoryName);
+        assertTrue(fakeBin.mkdirs());
+        File executable = new File(fakeBin, executableName);
+        Files.writeString(executable.toPath(), content);
+        assertTrue(executable.setExecutable(true));
+        return fakeBin;
     }
 }

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
@@ -5,6 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.domains.Domain;
+
 import hudson.FilePath;
 import hudson.model.Executor;
 import hudson.model.FreeStyleBuild;
@@ -18,6 +22,7 @@ import hudson.model.TaskListener;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.WorkspaceList;
+import hudson.util.Secret;
 
 import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeAgentHandler;
 import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeLogFormat;
@@ -26,6 +31,7 @@ import io.jenkins.plugins.aiagentjob.codex.CodexAgentHandler;
 import io.jenkins.plugins.aiagentjob.cursor.CursorAgentHandler;
 import io.jenkins.plugins.aiagentjob.opencode.OpenCodeAgentHandler;
 
+import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -458,12 +464,18 @@ class AiAgentBuildExecutionTest {
     void windowsCommandUsesCmdWithoutFlatteningLaunchMode() {
         List<String> command =
                 AiAgentExecutor.buildWindowsCommand(
-                        List.of("codex", "exec", "prompt with spaces", "100% literal"));
+                        List.of(
+                                "codex",
+                                "exec",
+                                "prompt with spaces",
+                                "%OPENAI_API_KEY%",
+                                "100% literal"));
 
         assertEquals("cmd.exe", command.get(0));
         assertEquals("/C", command.get(1));
         String commandLine = String.join(" ", command.subList(2, command.size()));
         assertTrue(commandLine.contains("prompt with spaces"));
+        assertFalse(commandLine.contains("%OPENAI_API_KEY%"));
         assertTrue(commandLine.contains("100% literal"));
     }
 
@@ -598,6 +610,17 @@ class AiAgentBuildExecutionTest {
     @EnabledOnOs(OS.LINUX)
     void openCodeAcp_waitsForJenkinsApprovalBeforeToolExecution(JenkinsRule jenkins)
             throws Exception {
+        String approvalSecret = "approval-secret-not-for-progressive-events";
+        StringCredentialsImpl credential =
+                new StringCredentialsImpl(
+                        CredentialsScope.GLOBAL,
+                        "approval-secret",
+                        "Approval secret",
+                        Secret.fromString(approvalSecret));
+        CredentialsProvider.lookupStores(jenkins.getInstance())
+                .iterator()
+                .next()
+                .addCredentials(Domain.global(), credential);
         File fakeBin = installFakeOpenCode(jenkins, "fake-opencode-bin");
 
         String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
@@ -610,6 +633,8 @@ class AiAgentBuildExecutionTest {
                             b.setPrompt("create approved.txt");
                             b.setRequireApprovals(true);
                             b.setApprovalTimeoutSeconds(30);
+                            b.setApiCredentialsId("approval-secret");
+                            b.setApiEnvVarName("FAKE_ACP_SECRET_INPUT");
                             b.setModel("test/provider-model");
                             b.setExtraArgs("--variant high --format json --pure");
                             b.setSetupScript("cd \"${WORKSPACE}\"");
@@ -624,6 +649,8 @@ class AiAgentBuildExecutionTest {
         FreeStyleBuild runningBuild = future.waitForStart();
         ExecutionRegistry.PendingApproval pending =
                 waitForPendingApproval(jenkins, runningBuild, future);
+        assertEquals("****", pending.getInputSummary());
+        assertFalse(pending.getInputSummary().contains(approvalSecret));
         AiAgentRunAction action = runningBuild.getAction(AiAgentRunAction.class);
         assertNotNull(action);
         ExecutionRegistry.LiveExecution liveExecution =
@@ -656,8 +683,42 @@ class AiAgentBuildExecutionTest {
         assertFalse(rawLog.contains("\"configOptions\""));
         assertFalse(rawLog.contains("private-test-command"));
         assertFalse(rawLog.contains("private-test-content"));
+        assertFalse(rawLog.contains(approvalSecret));
+        assertFalse(jenkins.getLog(build).contains(approvalSecret));
         assertTrue(action.getEvents().stream().anyMatch(e -> "tool_call".equals(e.getCategory())));
         assertTrue(action.getEvents().stream().anyMatch(e -> "assistant".equals(e.getCategory())));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void openCodeAcp_processExitCancelsPendingApproval(JenkinsRule jenkins) throws Exception {
+        File fakeBin = installFakeOpenCode(jenkins, "fake-opencode-exit-bin");
+        String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-opencode-acp-exit",
+                        b -> {
+                            b.setAgent(new OpenCodeAgentHandler());
+                            b.setPrompt("request then exit");
+                            b.setRequireApprovals(true);
+                            b.setApprovalTimeoutSeconds(30);
+                            b.setEnvironmentVariables(
+                                    "PATH=" + path + "\nFAKE_ACP_EXIT_AFTER_PERMISSION=1");
+                            b.setFailOnAgentError(true);
+                        });
+
+        long started = System.nanoTime();
+        FreeStyleBuild build = project.scheduleBuild2(0).get(10, TimeUnit.SECONDS);
+
+        jenkins.assertBuildStatus(Result.FAILURE, build);
+        assertTrue(
+                System.nanoTime() - started < TimeUnit.SECONDS.toNanos(10),
+                "Agent exit should not wait for approval timeout");
+        AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
+        assertNotNull(action);
+        assertTrue(action.getPendingApprovals().isEmpty());
+        assertTrue(jenkins.getLog(build).contains("agent process exited"));
     }
 
     private static ExecutionRegistry.PendingApproval waitForPendingApproval(

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
@@ -2,6 +2,7 @@ package io.jenkins.plugins.aiagentjob;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.jenkins.plugins.aiagentjob.claudecode.ClaudeCodeAgentHandler;
@@ -156,6 +157,19 @@ class AiAgentCommandFactoryTest {
         assertTrue(cmd.indexOf("--sandbox") < cmd.indexOf("exec"), "--sandbox is a global flag");
         assertTrue(approvalIdx < cmd.indexOf("exec"), "--ask-for-approval is a global flag");
         assertFalse(cmd.contains("--full-auto"), "Should not use removed --full-auto flag");
+    }
+
+    @Test
+    void codex_manualApprovalsAreRejected() {
+        AiAgentBuilder project = createProject(new CodexAgentHandler());
+        project.setRequireApprovals(true);
+
+        IllegalArgumentException error =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> AiAgentCommandFactory.buildDefaultCommand(project, "test"));
+
+        assertTrue(error.getMessage().contains("does not expose"));
     }
 
     @Test
@@ -425,26 +439,6 @@ class AiAgentCommandFactoryTest {
         assertEquals(2, vars.size());
         assertEquals("1", vars.get("A"));
         assertEquals("2", vars.get("B"));
-    }
-
-    // ======================== Command As String ========================
-
-    @Test
-    void commandAsString_joinsTokens() {
-        String result = AiAgentCommandFactory.commandAsString(List.of("echo", "hello", "world"));
-        assertEquals("echo hello world", result);
-    }
-
-    @Test
-    void commandAsString_quotesSpaces() {
-        String result = AiAgentCommandFactory.commandAsString(List.of("echo", "hello world"));
-        assertEquals("echo \"hello world\"", result);
-    }
-
-    @Test
-    void commandAsString_escapesQuotes() {
-        String result = AiAgentCommandFactory.commandAsString(List.of("echo", "say \"hi\""));
-        assertEquals("echo \"say \\\"hi\\\"\"", result);
     }
 
     // ======================== Model Without Value ========================

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
@@ -72,17 +72,16 @@ class AiAgentCommandFactoryTest {
     }
 
     @Test
-    void claudeCode_approvalsMode() {
+    void claudeCode_manualApprovalsAreRejected() {
         AiAgentBuilder project = createProject(new ClaudeCodeAgentHandler());
         project.setRequireApprovals(true);
 
-        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test prompt");
+        IllegalArgumentException error =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> AiAgentCommandFactory.buildDefaultCommand(project, "test prompt"));
 
-        assertTrue(
-                cmd.contains("--permission-mode=default"), "Should have --permission-mode=default");
-        assertFalse(
-                cmd.contains("--dangerously-skip-permissions"),
-                "Should NOT have --dangerously-skip-permissions");
+        assertTrue(error.getMessage().contains("ACP-capable"));
     }
 
     @Test
@@ -267,6 +266,19 @@ class AiAgentCommandFactoryTest {
         assertEquals("sonnet-4-thinking", cmd.get(modelIdx + 1));
     }
 
+    @Test
+    void cursorAgent_manualApprovalsAreRejected() {
+        AiAgentBuilder project = createProject(new CursorAgentHandler());
+        project.setRequireApprovals(true);
+
+        IllegalArgumentException error =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> AiAgentCommandFactory.buildDefaultCommand(project, "test"));
+
+        assertTrue(error.getMessage().contains("ACP-capable"));
+    }
+
     // ======================== OpenCode Command Tests ========================
 
     @Test
@@ -321,6 +333,20 @@ class AiAgentCommandFactoryTest {
         assertEquals("xhigh", execution.getReasoningEffort());
     }
 
+    @Test
+    void openCode_commandOverrideCannotUseManualApprovals() {
+        AiAgentBuilder project = createProject(new OpenCodeAgentHandler());
+        project.setRequireApprovals(true);
+        project.setCommandOverride("opencode acp --custom");
+
+        IllegalArgumentException error =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> AiAgentCommandFactory.buildDefaultCommand(project, "test"));
+
+        assertTrue(error.getMessage().contains("command override"));
+    }
+
     // ======================== Gemini CLI Command Tests ========================
 
     @Test
@@ -347,14 +373,16 @@ class AiAgentCommandFactoryTest {
     }
 
     @Test
-    void geminiCli_withApprovals() {
+    void geminiCli_manualApprovalsAreRejected() {
         AiAgentBuilder project = createProject(new GeminiCliAgentHandler());
         project.setRequireApprovals(true);
 
-        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+        IllegalArgumentException error =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> AiAgentCommandFactory.buildDefaultCommand(project, "test"));
 
-        assertTrue(cmd.contains("--approval-mode"), "Should have --approval-mode");
-        assertTrue(cmd.contains("default"), "Should have default");
+        assertTrue(error.getMessage().contains("ACP-capable"));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCredentialInjectionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCredentialInjectionTest.java
@@ -165,6 +165,47 @@ class AiAgentCredentialInjectionTest {
 
     @Test
     @EnabledOnOs(OS.LINUX)
+    void masksJsonEscapedCredentialValues(JenkinsRule jenkins) throws Exception {
+        String secret = "double\"quote\\path";
+        String jsonEscapedSecret = "double\\\"quote\\\\path";
+        StringCredentialsImpl cred =
+                new StringCredentialsImpl(
+                        CredentialsScope.GLOBAL,
+                        "json-escaped-key",
+                        "JSON escaped key",
+                        Secret.fromString(secret));
+        CredentialsProvider.lookupStores(jenkins.getInstance())
+                .iterator()
+                .next()
+                .addCredentials(Domain.global(), cred);
+
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "json-escaped-credential-test",
+                        b -> {
+                            b.setAgent(new ClaudeCodeAgentHandler());
+                            b.setApiCredentialsId("json-escaped-key");
+                            b.setCommandOverride(
+                                    "printf '%s\\n' '{\"type\":\"system\",\"message\":\"double\\\"quote\\\\path\"}'");
+                        });
+
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+        AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
+        assertNotNull(action);
+        String rawLog = Files.readString(action.getRawLogFile().toPath(), StandardCharsets.UTF_8);
+        String buildLog = build.getLog();
+
+        for (String secretVariant : new String[] {secret, jsonEscapedSecret}) {
+            assertFalse(rawLog.contains(secretVariant), "Raw log leaked credential variant");
+            assertFalse(buildLog.contains(secretVariant), "Build log leaked credential variant");
+        }
+        assertTrue(rawLog.contains("\"message\":\"****\""));
+        assertTrue(buildLog.contains("\"message\":\"****\""));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
     void warnsWhenCredentialNotFound(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project =
                 newProject(

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCredentialInjectionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCredentialInjectionTest.java
@@ -66,7 +66,7 @@ class AiAgentCredentialInjectionTest {
                             b.setPrompt("test");
                             b.setApiCredentialsId("test-api-key");
                             b.setCommandOverride(
-                                    "echo \"{\\\"type\\\":\\\"system\\\",\\\"key_set\\\":\\\"$(test -n \\\"$ANTHROPIC_API_KEY\\\" && echo yes || echo no)\\\"}\"");
+                                    "echo \"{\\\"type\\\":\\\"system\\\",\\\"key_set\\\":\\\"$(test -n \\\"$ANTHROPIC_API_KEY\\\" && echo yes || echo no)\\\",\\\"key\\\":\\\"$ANTHROPIC_API_KEY\\\"}\"");
                             b.setFailOnAgentError(true);
                         });
 
@@ -76,11 +76,14 @@ class AiAgentCredentialInjectionTest {
 
         String rawLog = Files.readString(action.getRawLogFile().toPath(), StandardCharsets.UTF_8);
         assertTrue(rawLog.contains("\"key_set\":\"yes\""), "Env var should have been set");
+        assertTrue(rawLog.contains("\"key\":\"****\""), "Raw log should mask the API key");
+        assertFalse(rawLog.contains("sk-test-secret-12345"));
 
         String buildLog = build.getLog();
         assertTrue(
                 buildLog.contains("API key injected as ANTHROPIC_API_KEY"),
                 "Build log should mention API key injection");
+        assertFalse(buildLog.contains("sk-test-secret-12345"));
     }
 
     @Test
@@ -116,6 +119,48 @@ class AiAgentCredentialInjectionTest {
         assertTrue(
                 buildLog.contains("API key injected as ANTHROPIC_API_KEY"),
                 "Should inject as ANTHROPIC_API_KEY not OPENAI_API_KEY");
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void masksMultilineAndShellMangledCredentialValues(JenkinsRule jenkins) throws Exception {
+        String firstLine = "multiline-secret-first";
+        String secondLine = "second-line's-secret";
+        StringCredentialsImpl cred =
+                new StringCredentialsImpl(
+                        CredentialsScope.GLOBAL,
+                        "multiline-key",
+                        "Multiline key",
+                        Secret.fromString(firstLine + "\n" + secondLine));
+        CredentialsProvider.lookupStores(jenkins.getInstance())
+                .iterator()
+                .next()
+                .addCredentials(Domain.global(), cred);
+
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "multiline-credential-test",
+                        b -> {
+                            b.setAgent(new ClaudeCodeAgentHandler());
+                            b.setApiCredentialsId("multiline-key");
+                            b.setSetupScript("true");
+                            b.setCommandOverride("printf '%s\\n' \"$ANTHROPIC_API_KEY\"");
+                        });
+
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+        AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
+        assertNotNull(action);
+        String rawLog = Files.readString(action.getRawLogFile().toPath(), StandardCharsets.UTF_8);
+        String buildLog = build.getLog();
+
+        for (String secretFragment :
+                new String[] {firstLine, secondLine, "second-line'\\''s-secret"}) {
+            assertFalse(rawLog.contains(secretFragment), "Raw log leaked credential fragment");
+            assertFalse(buildLog.contains(secretFragment), "Build log leaked credential fragment");
+        }
+        assertTrue(rawLog.contains("****"));
+        assertTrue(buildLog.contains("****"));
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentExecutionCustomizationTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentExecutionCustomizationTest.java
@@ -1,0 +1,33 @@
+package io.jenkins.plugins.aiagentjob;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import hudson.model.TaskListener;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class AiAgentExecutionCustomizationTest {
+
+    @Test
+    void cleanup_restoresInterruptAndRunsRemainingActions() {
+        Thread.interrupted();
+        AtomicBoolean secondActionRan = new AtomicBoolean();
+        AiAgentExecutionCustomization customization = AiAgentExecutionCustomization.empty();
+        customization.addCleanupAction(
+                () -> {
+                    throw new InterruptedException("interrupted cleanup");
+                });
+        customization.addCleanupAction(() -> secondActionRan.set(true));
+
+        try {
+            customization.cleanup(TaskListener.NULL);
+
+            assertTrue(secondActionRan.get());
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            Thread.interrupted();
+        }
+    }
+}

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentLogParserTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentLogParserTest.java
@@ -388,6 +388,29 @@ class AiAgentLogParserTest {
         assertTrue(assistant.getContent().contains("AI Agent"));
     }
 
+    @Test
+    void openCodeStreaming_mergesThoughtChunks() throws IOException {
+        File temp = File.createTempFile("opencode-thought-deltas-", ".jsonl");
+        temp.deleteOnExit();
+        Files.write(
+                temp.toPath(),
+                List.of(
+                        "{\"method\":\"session/update\",\"params\":{\"update\":{"
+                                + "\"sessionUpdate\":\"agent_thought_chunk\",\"content\":{"
+                                + "\"type\":\"text\",\"text\":\"Inspect-\"}}}}",
+                        "{\"method\":\"session/update\",\"params\":{\"update\":{"
+                                + "\"sessionUpdate\":\"agent_thought_chunk\",\"content\":{"
+                                + "\"type\":\"text\",\"text\":\"tests\"}}}}"));
+
+        List<AiAgentLogParser.EventView> events =
+                AiAgentLogParser.parse(temp, OpenCodeLogFormat.INSTANCE);
+
+        assertEquals(1, events.size());
+        assertEquals("thinking", events.get(0).getCategory());
+        assertEquals("Inspect-tests", events.get(0).getContent());
+        assertFalse(events.get(0).isDelta(), "Merged stream event should no longer be a delta");
+    }
+
     // ======================== Error Handling Tests ========================
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentLogParserTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentLogParserTest.java
@@ -104,6 +104,81 @@ class AiAgentLogParserTest {
     }
 
     @Test
+    void claudeCodeContentArray_preservesParallelToolCallsWithAndWithoutExplicitFormat() {
+        String json =
+                "{\"type\":\"assistant\",\"message\":{\"content\":["
+                        + "{\"type\":\"tool_use\",\"id\":\"call-1\",\"name\":\"Bash\","
+                        + "\"input\":{\"command\":\"pwd\"}},"
+                        + "{\"type\":\"tool_use\",\"id\":\"call-2\",\"name\":\"Read\","
+                        + "\"input\":{\"file_path\":\"README.md\"}}]}}";
+
+        for (AiAgentLogFormat format :
+                new AiAgentLogFormat[] {ClaudeCodeLogFormat.INSTANCE, null}) {
+            List<AiAgentLogParser.ParsedLine> parsed = AiAgentLogParser.parseLines(1, json, format);
+
+            assertEquals(2, parsed.size());
+            assertTrue(parsed.stream().allMatch(AiAgentLogParser.ParsedLine::isToolCall));
+            assertEquals("call-1", parsed.get(0).getToolCallIdOrGenerated());
+            assertEquals("call-2", parsed.get(1).getToolCallIdOrGenerated());
+        }
+    }
+
+    @Test
+    void claudeCodeStreaming_mergesTextDeltas() throws IOException {
+        File temp = File.createTempFile("claude-deltas-", ".jsonl");
+        temp.deleteOnExit();
+        Files.write(
+                temp.toPath(),
+                List.of(
+                        "{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\","
+                                + "\"delta\":{\"type\":\"text_delta\",\"text\":\"Hello \"}}}",
+                        "{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\","
+                                + "\"delta\":{\"type\":\"text_delta\",\"text\":\"world\"}}}"));
+
+        List<AiAgentLogParser.EventView> events =
+                AiAgentLogParser.parse(temp, ClaudeCodeLogFormat.INSTANCE);
+
+        assertEquals(1, events.size());
+        assertEquals("assistant", events.get(0).getCategory());
+        assertEquals("Hello world", events.get(0).getContent());
+    }
+
+    @Test
+    void claudeCodeStreaming_mergesThinkingDeltas() throws IOException {
+        File temp = File.createTempFile("claude-thinking-deltas-", ".jsonl");
+        temp.deleteOnExit();
+        Files.write(
+                temp.toPath(),
+                List.of(
+                        "{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\","
+                                + "\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"Inspect \"}}}",
+                        "{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_delta\","
+                                + "\"delta\":{\"type\":\"thinking_delta\",\"thinking\":\"tests\"}}}"));
+
+        List<AiAgentLogParser.EventView> events =
+                AiAgentLogParser.parse(temp, ClaudeCodeLogFormat.INSTANCE);
+
+        assertEquals(1, events.size());
+        assertEquals("thinking", events.get(0).getCategory());
+        assertEquals("Inspect tests", events.get(0).getContent());
+    }
+
+    @Test
+    void claudeCodeStreaming_hidesStructuralEvents() throws IOException {
+        File temp = File.createTempFile("claude-structure-", ".jsonl");
+        temp.deleteOnExit();
+        Files.write(
+                temp.toPath(),
+                List.of(
+                        "{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_start\","
+                                + "\"content_block\":{\"type\":\"text\",\"text\":\"\"}}}",
+                        "{\"type\":\"stream_event\",\"event\":{\"type\":\"content_block_stop\"}}",
+                        "{\"type\":\"stream_event\",\"event\":{\"type\":\"message_stop\"}}"));
+
+        assertTrue(AiAgentLogParser.parse(temp, ClaudeCodeLogFormat.INSTANCE).isEmpty());
+    }
+
+    @Test
     void claudeCodeToolUseApproval_detectsMultipleToolCalls() throws IOException {
         List<AiAgentLogParser.EventView> events =
                 parseFixture("claude-code-tool-use-approval.jsonl", ClaudeCodeLogFormat.INSTANCE);
@@ -664,7 +739,10 @@ class AiAgentLogParserTest {
     void claudeCodeConversation_hasCorrectEventCount() throws IOException {
         List<AiAgentLogParser.EventView> events =
                 parseFixture("claude-code-conversation.jsonl", ClaudeCodeLogFormat.INSTANCE);
-        assertTrue(events.size() >= 5, "Should have at least 5 events for a full conversation");
+        assertEquals(
+                10,
+                events.size(),
+                "Cumulative Claude snapshots should produce 10 distinct visible events");
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRunActionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRunActionTest.java
@@ -16,6 +16,7 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlScript;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -25,6 +26,7 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 import java.io.File;
 import java.io.InputStream;
 import java.lang.reflect.Field;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
@@ -348,6 +350,33 @@ class AiAgentRunActionTest {
         assertTrue(text.contains("AI Agent Conversation #1"));
         assertFalse(text.contains("Explain this repository in detail"));
         assertTrue(text.contains("Raw Log"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void conversationPage_loadsMarkedBundleFromJenkinsContextPath(JenkinsRule jenkins)
+            throws Exception {
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "test-conversation-markdown-sanitizer",
+                        b ->
+                                b.setCommandOverride(
+                                        "printf '%s\\n' '{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"[unsafe](javascript:alert(1))\"}]}}'"));
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+
+        JenkinsRule.WebClient wc = jenkins.createWebClient();
+        wc.getOptions().setJavaScriptEnabled(false);
+        HtmlPage page = wc.goTo(build.getUrl() + "ai-agent/conversation?invocation=1");
+
+        HtmlScript markedScript =
+                page.getFirstByXPath("//script[contains(@src, '/js/bundles/marked.umd.js')]");
+        assertNotNull(markedScript, "Conversation page should include the Marked bundle");
+        URL markedUrl = page.getFullyQualifiedUrl(markedScript.getSrcAttribute());
+        assertTrue(
+                markedUrl.getPath().startsWith(jenkins.getURL().getPath()),
+                "Marked bundle URL should preserve the Jenkins context path");
+        assertEquals(200, wc.getPage(markedUrl).getWebResponse().getStatusCode());
     }
 
     private String buildCatScript(String fixtureName) throws Exception {

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRunActionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRunActionTest.java
@@ -24,6 +24,7 @@ import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import java.io.File;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.List;
@@ -69,6 +70,14 @@ class AiAgentRunActionTest {
                         b -> b.setCommandOverride("echo '{\"type\":\"system\"}'"));
         FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
         int buildNumber = build.getNumber();
+        AiAgentRunAction initialAction = build.getAction(AiAgentRunAction.class);
+        assertNotNull(initialAction);
+        AiAgentRunAction.InvocationRecord legacyInvocation = initialAction.getInvocations().get(0);
+        setField(legacyInvocation, "prompt", "legacy-sensitive-prompt");
+        setField(legacyInvocation, "commandLine", "legacy-sensitive-command");
+        build.save();
+        File buildXml = new File(build.getRootDir(), "build.xml");
+        assertTrue(Files.readString(buildXml.toPath()).contains("legacy-sensitive-prompt"));
 
         jenkins.jenkins.reload();
 
@@ -79,12 +88,21 @@ class AiAgentRunActionTest {
         assertNotNull(reloadedBuild);
         AiAgentRunAction action = reloadedBuild.getAction(AiAgentRunAction.class);
         assertNotNull(action);
+        AiAgentRunAction.InvocationRecord scrubbedInvocation = action.getInvocations().get(0);
+        assertEquals("", scrubbedInvocation.getPrompt());
+        assertEquals("", scrubbedInvocation.getCommandLine());
+        String scrubbedBuildXml = Files.readString(buildXml.toPath());
+        assertFalse(scrubbedBuildXml.contains("legacy-sensitive-prompt"));
+        assertFalse(scrubbedBuildXml.contains("legacy-sensitive-command"));
 
         int invocationId =
                 action.markStarted("Codex", "continue", "gpt-5.5", "codex exec", false, false);
 
         assertEquals(2, invocationId);
         assertEquals(2, action.getInvocations().size());
+        AiAgentRunAction.InvocationRecord invocation = action.getInvocations().get(1);
+        assertEquals("", invocation.getPrompt());
+        assertEquals("", invocation.getCommandLine());
     }
 
     @Test
@@ -308,7 +326,7 @@ class AiAgentRunActionTest {
 
     @Test
     @EnabledOnOs(OS.LINUX)
-    void conversationPage_showsPromptAndFullConversationLinkTarget(JenkinsRule jenkins)
+    void conversationPage_hidesPromptAndShowsFullConversationLinkTarget(JenkinsRule jenkins)
             throws Exception {
         FreeStyleProject project =
                 newProject(
@@ -328,7 +346,7 @@ class AiAgentRunActionTest {
         String text = page.asNormalizedText();
 
         assertTrue(text.contains("AI Agent Conversation #1"));
-        assertTrue(text.contains("Explain this repository in detail"));
+        assertFalse(text.contains("Explain this repository in detail"));
         assertTrue(text.contains("Raw Log"));
     }
 
@@ -347,5 +365,11 @@ class AiAgentRunActionTest {
             assertNotNull(is, "Resource should exist: " + resourcePath);
             return new String(is.readAllBytes(), StandardCharsets.UTF_8);
         }
+    }
+
+    private static void setField(Object target, String name, String value) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(target, value);
     }
 }

--- a/src/test/java/io/jenkins/plugins/aiagentjob/ExecutionRegistryTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/ExecutionRegistryTest.java
@@ -59,6 +59,19 @@ class ExecutionRegistryTest {
     }
 
     @Test
+    void approveBeforeAwait_resolvesDecision() {
+        ExecutionRegistry.LiveExecution live = new ExecutionRegistry.LiveExecution();
+        ExecutionRegistry.PendingApproval pending =
+                live.createPendingApproval("tc-1", "bash", "ls");
+
+        assertTrue(live.approve(pending.getId()));
+
+        ExecutionRegistry.ApprovalDecision decision =
+                live.awaitDecision(pending, Duration.ofSeconds(1));
+        assertTrue(decision.isApproved(), "Early approval should remain available to the executor");
+    }
+
+    @Test
     void deny_resolvesDecision() {
         ExecutionRegistry.LiveExecution live = new ExecutionRegistry.LiveExecution();
         ExecutionRegistry.PendingApproval pending =
@@ -117,5 +130,25 @@ class ExecutionRegistryTest {
     void deny_returnsFalseForUnknownId() {
         ExecutionRegistry.LiveExecution live = new ExecutionRegistry.LiveExecution();
         assertFalse(live.deny("nonexistent-id", "reason"));
+    }
+
+    @Test
+    void cancelPendingApprovals_deniesWaitersAndClearsCards() {
+        ExecutionRegistry.LiveExecution live = new ExecutionRegistry.LiveExecution();
+        ExecutionRegistry.PendingApproval first = live.createPendingApproval("tc-1", "bash", "ls");
+        ExecutionRegistry.PendingApproval second =
+                live.createPendingApproval("tc-2", "read", "README.md");
+
+        live.cancelPendingApprovals("build aborted");
+
+        assertTrue(live.getPendingApprovals().isEmpty());
+        ExecutionRegistry.ApprovalDecision firstDecision =
+                live.awaitDecision(first, Duration.ofSeconds(1));
+        ExecutionRegistry.ApprovalDecision secondDecision =
+                live.awaitDecision(second, Duration.ofSeconds(1));
+        assertFalse(firstDecision.isApproved());
+        assertFalse(secondDecision.isApproved());
+        assertEquals("build aborted", firstDecision.getReason());
+        assertEquals("build aborted", secondDecision.getReason());
     }
 }

--- a/src/test/java/io/jenkins/plugins/aiagentjob/ExecutionRegistryTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/ExecutionRegistryTest.java
@@ -36,7 +36,7 @@ class ExecutionRegistryTest {
     }
 
     @Test
-    void approve_resolvesDecision() {
+    void approve_resolvesDecision() throws Exception {
         ExecutionRegistry.LiveExecution live = new ExecutionRegistry.LiveExecution();
         ExecutionRegistry.PendingApproval pending =
                 live.createPendingApproval("tc-1", "bash", "ls");
@@ -59,7 +59,7 @@ class ExecutionRegistryTest {
     }
 
     @Test
-    void approveBeforeAwait_resolvesDecision() {
+    void approveBeforeAwait_resolvesDecision() throws Exception {
         ExecutionRegistry.LiveExecution live = new ExecutionRegistry.LiveExecution();
         ExecutionRegistry.PendingApproval pending =
                 live.createPendingApproval("tc-1", "bash", "ls");
@@ -72,7 +72,7 @@ class ExecutionRegistryTest {
     }
 
     @Test
-    void deny_resolvesDecision() {
+    void deny_resolvesDecision() throws Exception {
         ExecutionRegistry.LiveExecution live = new ExecutionRegistry.LiveExecution();
         ExecutionRegistry.PendingApproval pending =
                 live.createPendingApproval("tc-1", "bash", "rm -rf /");
@@ -95,7 +95,7 @@ class ExecutionRegistryTest {
     }
 
     @Test
-    void timeout_deniesDecision() {
+    void timeout_deniesDecision() throws Exception {
         ExecutionRegistry.LiveExecution live = new ExecutionRegistry.LiveExecution();
         ExecutionRegistry.PendingApproval pending =
                 live.createPendingApproval("tc-1", "bash", "ls");
@@ -133,7 +133,7 @@ class ExecutionRegistryTest {
     }
 
     @Test
-    void cancelPendingApprovals_deniesWaitersAndClearsCards() {
+    void cancelPendingApprovals_deniesWaitersAndClearsCards() throws Exception {
         ExecutionRegistry.LiveExecution live = new ExecutionRegistry.LiveExecution();
         ExecutionRegistry.PendingApproval first = live.createPendingApproval("tc-1", "bash", "ls");
         ExecutionRegistry.PendingApproval second =

--- a/src/test/java/io/jenkins/plugins/aiagentjob/ExecutionRegistryTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/ExecutionRegistryTest.java
@@ -110,6 +110,21 @@ class ExecutionRegistryTest {
     }
 
     @Test
+    void cancellationBeforeApprovalCreation_deniesNewApproval() throws Exception {
+        ExecutionRegistry.LiveExecution live = new ExecutionRegistry.LiveExecution();
+        live.cancelPendingApprovals("agent process exited while waiting for approval");
+        ExecutionRegistry.PendingApproval pending =
+                live.createPendingApproval("tc-1", "bash", "ls");
+
+        ExecutionRegistry.ApprovalDecision decision =
+                live.awaitDecision(pending, Duration.ofSeconds(1));
+
+        assertFalse(decision.isApproved());
+        assertTrue(decision.getReason().contains("agent process exited"));
+        assertTrue(live.getPendingApprovals().isEmpty());
+    }
+
+    @Test
     void approvalDecision_factoryMethods() {
         ExecutionRegistry.ApprovalDecision approved = ExecutionRegistry.ApprovalDecision.approved();
         assertTrue(approved.isApproved());

--- a/src/test/js/summary_resources.test.js
+++ b/src/test/js/summary_resources.test.js
@@ -1,10 +1,26 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
+const { parseHTML } = require('linkedom');
+
+const { document, window } = parseHTML(
+  '<!doctype html><html><body><div data-ai-agent-root="true"><div class="ai-md-src" data-md="not rendered"></div></div></body></html>',
+  { location: { href: 'https://jenkins.example/job/test/1/' } }
+);
+
+global.document = document;
+global.window = window;
 
 const {
+  appendDelta,
   buildApprovalUrl,
-  isSafeUrl
+  isSafeUrl,
+  renderEvent,
+  sanitizeHtml
 } = require('../../main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary_resources.js');
+
+test('CommonJS export does not initialize page rendering', function () {
+  assert.equal(document.querySelector('.ai-md-src').innerHTML, '');
+});
 
 test('approval URL preserves invocation and encodes approval parameters', function () {
   const result = new URL(buildApprovalUrl(
@@ -34,4 +50,74 @@ test('rendered images reject mailto and non-web protocols', function () {
   assert.equal(isSafeUrl('https://example.com/image.png', false, baseUrl), true);
   assert.equal(isSafeUrl('mailto:owner@example.com', false, baseUrl), false);
   assert.equal(isSafeUrl('file:///etc/passwd', false, baseUrl), false);
+});
+
+test('sanitizer removes unsafe markup and preserves permitted content', function () {
+  const output = document.createElement('div');
+  output.innerHTML = sanitizeHtml(
+    '<p onclick="alert(1)">Safe <a href="javascript:alert(1)" title="blocked">link</a>'
+      + '<a href="https://example.com" onclick="alert(1)">allowed</a>'
+      + '<img src="data:image/svg+xml,unsafe" alt="unsafe" onerror="alert(1)">'
+      + '<script>alert(1)</script></p>'
+  );
+
+  const links = output.querySelectorAll('a');
+  assert.equal(output.querySelector('p').hasAttribute('onclick'), false);
+  assert.equal(links[0].hasAttribute('href'), false);
+  assert.equal(links[0].getAttribute('title'), 'blocked');
+  assert.equal(links[1].getAttribute('href'), 'https://example.com');
+  assert.equal(links[1].hasAttribute('onclick'), false);
+  assert.equal(output.querySelector('img').hasAttribute('src'), false);
+  assert.equal(output.querySelector('img').getAttribute('alt'), 'unsafe');
+  assert.equal(output.querySelector('script'), null);
+  assert.match(output.textContent, /Safe linkallowedalert\(1\)/);
+});
+
+test('assistant delta rerenders accumulated markdown in latest assistant event', function () {
+  const container = document.createElement('div');
+  container.insertAdjacentHTML('beforeend', renderEvent({
+    category: 'assistant',
+    label: 'Assistant',
+    content: 'Hello'
+  }));
+
+  assert.equal(appendDelta(container, {
+    category: 'assistant',
+    delta: true,
+    content: ' **world**'
+  }), true);
+
+  const assistant = container.querySelector('.ai-msg-content-assistant');
+  assert.equal(assistant.getAttribute('data-md'), 'Hello **world**');
+  assert.equal(assistant.textContent, 'Hello world');
+  assert.match(assistant.innerHTML, /<strong>world<\/strong>/);
+});
+
+test('thinking delta appends text only to latest thinking event', function () {
+  const container = document.createElement('div');
+  container.insertAdjacentHTML('beforeend', renderEvent({
+    category: 'assistant',
+    label: 'Assistant',
+    content: 'Answer'
+  }));
+  container.insertAdjacentHTML('beforeend', renderEvent({
+    category: 'thinking',
+    label: 'Thinking',
+    content: 'First'
+  }));
+
+  assert.equal(appendDelta(container, {
+    category: 'thinking',
+    delta: true,
+    content: ' second'
+  }), true);
+
+  const thinking = container.querySelector('.ai-thinking-text');
+  assert.equal(thinking.getAttribute('data-content'), 'First second');
+  assert.equal(thinking.textContent, 'First second');
+  assert.equal(appendDelta(container, {
+    category: 'assistant',
+    delta: true,
+    content: ' ignored'
+  }), false);
 });

--- a/src/test/js/summary_resources.test.js
+++ b/src/test/js/summary_resources.test.js
@@ -1,0 +1,37 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  buildApprovalUrl,
+  isSafeUrl
+} = require('../../main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary_resources.js');
+
+test('approval URL preserves invocation and encodes approval parameters', function () {
+  const result = new URL(buildApprovalUrl(
+    'https://jenkins.example/job/test/1/ai-agent/deny?invocation=7',
+    'approval id',
+    'needs review & retry'
+  ));
+
+  assert.equal(result.searchParams.get('invocation'), '7');
+  assert.equal(result.searchParams.get('id'), 'approval id');
+  assert.equal(result.searchParams.get('reason'), 'needs review & retry');
+});
+
+test('rendered links accept only safe protocols', function () {
+  const baseUrl = 'https://jenkins.example/job/test/1/';
+
+  assert.equal(isSafeUrl('/artifact/report.html', true, baseUrl), true);
+  assert.equal(isSafeUrl('https://example.com/report', true, baseUrl), true);
+  assert.equal(isSafeUrl('mailto:owner@example.com', true, baseUrl), true);
+  assert.equal(isSafeUrl('javascript:alert(1)', true, baseUrl), false);
+  assert.equal(isSafeUrl('data:text/html,unsafe', true, baseUrl), false);
+});
+
+test('rendered images reject mailto and non-web protocols', function () {
+  const baseUrl = 'https://jenkins.example/job/test/1/';
+
+  assert.equal(isSafeUrl('https://example.com/image.png', false, baseUrl), true);
+  assert.equal(isSafeUrl('mailto:owner@example.com', false, baseUrl), false);
+  assert.equal(isSafeUrl('file:///etc/passwd', false, baseUrl), false);
+});

--- a/src/test/resources/io/jenkins/plugins/aiagentjob/fixtures/fake-opencode-acp.sh
+++ b/src/test/resources/io/jenkins/plugins/aiagentjob/fixtures/fake-opencode-acp.sh
@@ -28,7 +28,12 @@ while IFS= read -r request; do
 done
 printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"available_commands_update","availableCommands":[{"name":"private-test-command","description":"control metadata"}]}}}'
 printf '%s\n' '{"jsonrpc":"2.0","method":"session/update","params":{"sessionId":"session-1","update":{"sessionUpdate":"tool_call","toolCallId":"call-1","title":"touch approved.txt","kind":"execute","status":"pending","rawInput":{"command":"touch approved.txt"}}}}'
-printf '%s\n' '{"jsonrpc":"2.0","id":"permission-1","method":"session/request_permission","params":{"sessionId":"session-1","toolCall":{"toolCallId":"call-1","title":"touch approved.txt","kind":"execute","status":"pending","rawInput":{"command":"touch approved.txt"}},"options":[{"optionId":"once","name":"Allow once","kind":"allow_once"},{"optionId":"reject","name":"Reject","kind":"reject_once"}]}}'
+approval_input=${FAKE_ACP_SECRET_INPUT:-touch approved.txt}
+printf '%s\n' "{\"jsonrpc\":\"2.0\",\"id\":\"permission-1\",\"method\":\"session/request_permission\",\"params\":{\"sessionId\":\"session-1\",\"toolCall\":{\"toolCallId\":\"call-1\",\"title\":\"touch approved.txt\",\"kind\":\"execute\",\"status\":\"pending\",\"rawInput\":{\"command\":\"$approval_input\"}},\"options\":[{\"optionId\":\"once\",\"name\":\"Allow once\",\"kind\":\"allow_once\"},{\"optionId\":\"reject\",\"name\":\"Reject\",\"kind\":\"reject_once\"}]}}"
+
+if test "${FAKE_ACP_EXIT_AFTER_PERMISSION:-}" = "1"; then
+  exit 23
+fi
 
 IFS= read -r approval_response
 printf '%s\n' "$approval_response" > approval-response.json


### PR DESCRIPTION
## Summary

Completes a full defect review of agent execution, approvals, log handling, credential safety, rendering, and release workflows.

## Changes

- uses OpenCode ACP as the only bidirectional manual-approval path and rejects unsupported agent or command-override combinations before launch
- preserves Jenkins abort semantics, process cleanup, remote-node temp paths, Windows command shims, and macro-expanded model/reasoning settings
- masks raw, JSON-escaped, and approval-card credential variants; prevents Windows environment expansion; cancels approval waits when agent processes exit
- disables shell tracing, makes generated scripts and Codex config owner-only, and stops persisting prompt or command metadata
- preserves multi-block Claude events, deduplicates cumulative snapshots, merges streamed assistant/thinking deltas, and saturates token counters
- sanitizes rendered Markdown URLs, preserves approval query parameters, fixes standalone conversation resource URLs under Jenkins context paths, and executes sanitizer/delta tests against a DOM
- limits workflow permissions and pins reusable release/security workflows to verified release commits

## Testing

- `mvn -B -ntp clean verify` and captured `mvn -B -ntp verify` (212 tests, 1 skipped; SpotBugs 0 findings; HPI built)
- `npm ci` and `npm test` (7 DOM/JavaScript tests plus syntax check)
- `npm audit --audit-level=high` (0 vulnerabilities)
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -color`
- JenkinsRule integration coverage for remote aborts, approval secrecy/process exit, temp/config permissions, setup secrecy, and context-path resource loading
- current Codex CLI command validated with `gpt-5.5` and `xhigh`; OpenCode ACP model/effort session configuration validated against a local server

## Validation limits

No real Windows executor, Cursor CLI, usable Gemini CLI configuration, or interactive browser session was available locally. Windows quoting has structural coverage; browser behavior has executable DOM coverage plus Jenkins context-path asset loading; GitHub and Jenkins CI provide fresh Java 17/21 Linux validation.

## Rollback

Revert the PR merge commit. No schema migration is required; legacy prompt and command metadata is scrubbed when build actions load.
