### PR TITLE
[core] Support configurable agent executable paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,14 @@ The plugin injects these variables into every build:
 | `AI_AGENT_MODEL` | The configured model name |
 | `AI_AGENT_REASONING_EFFORT` | The configured reasoning effort |
 
+### Executable Path
+
+Jenkins services and agents do not load interactive shell startup files, so their `PATH` often
+differs from an interactive terminal. Set **Executable path** to the agent launcher on the build
+node, such as `$HOME/.local/bin/codex`. The plugin keeps the generated arguments and replaces only
+the executable. For Claude Code, this setting replaces the `npx` launcher; use **Command override**
+when the entire command shape must change.
+
 ### Setup Script
 
 The **Setup script** field accepts shell commands that run before the agent process starts on
@@ -137,25 +145,27 @@ Use it to prepare the build environment — install dependencies, source dotfile
 or map Jenkins-bound credentials into variables that the agent needs at runtime.
 
 ```bash
-# Example: add local binaries to PATH, source nvm, install a CLI tool
+# Example: add local binaries to PATH, load nvm, install a CLI tool
 export PATH="$HOME/.local/bin:$PATH"
-source "$HOME/.nvm/nvm.sh"
+. "$HOME/.nvm/nvm.sh"
 nvm use 22
 npm install -g @anthropic-ai/claude-code
 ```
 
 The setup script and agent command run in the **same shell session**, so any `export`ed
 variables, PATH changes, or sourced dotfiles are available to the agent. Supports shebang
-lines (e.g. `#!/bin/zsh`) — if no shebang is present, `/bin/sh -e` is used. If the script exits
-with a non-zero code the build fails immediately without launching the agent. Shell tracing is
+lines (e.g. `#!/bin/zsh`) — if no shebang is present, `/bin/sh -e` is used and the script must use
+POSIX syntax such as `. file`. Add a Bash or Zsh shebang before using `source`; add `set -e` when
+that interpreter should stop on the first error. If the script exits with a non-zero code the build
+fails immediately without launching the agent. Shell tracing is
 disabled for setup and generated agent commands so expanded values, prompts, and arguments are not
 written to the build log. On Windows nodes, use **Command override** instead.
 
 ### Command Override
 
 **Command override** runs a single shell command or shell snippet instead of the built-in
-agent command. Use this when you need full control over the launched process or want to invoke
-the agent from a custom path.
+agent command. Use **Executable path** for a custom binary location while retaining generated
+arguments; use **Command override** when you need full control over the launched process.
 
 ### Codex Job-Scoped config.toml
 

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentBuilder.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentBuilder.java
@@ -45,6 +45,7 @@ public class AiAgentBuilder extends Builder implements SimpleBuildStep, AiAgentC
     private String reasoningEffort = "";
     private String prompt = "";
     private String workingDirectory = "";
+    private String executablePath = "";
     private boolean yoloMode;
     private boolean requireApprovals;
     private int approvalTimeoutSeconds = 600;
@@ -136,6 +137,16 @@ public class AiAgentBuilder extends Builder implements SimpleBuildStep, AiAgentC
     @DataBoundSetter
     public void setWorkingDirectory(String workingDirectory) {
         this.workingDirectory = Util.fixNull(workingDirectory);
+    }
+
+    @Override
+    public String getExecutablePath() {
+        return executablePath;
+    }
+
+    @DataBoundSetter
+    public void setExecutablePath(String executablePath) {
+        this.executablePath = Util.fixNull(executablePath).trim();
     }
 
     @Override
@@ -261,6 +272,7 @@ public class AiAgentBuilder extends Builder implements SimpleBuildStep, AiAgentC
         reasoningEffort = Util.fixNull(reasoningEffort);
         prompt = Util.fixNull(prompt);
         workingDirectory = Util.fixNull(workingDirectory);
+        executablePath = Util.fixNull(executablePath).trim();
         commandOverride = normalizeCommandOverride(commandOverride);
         extraArgs = Util.fixNull(extraArgs);
         environmentVariables = Util.fixNull(environmentVariables);

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactory.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactory.java
@@ -24,7 +24,20 @@ final class AiAgentCommandFactory {
         if (extraArgs != null) {
             Collections.addAll(command, Util.tokenize(extraArgs));
         }
-        return command;
+        return applyExecutablePath(command, config.getExecutablePath());
+    }
+
+    static List<String> applyExecutablePath(List<String> command, String executablePath) {
+        String executable = Util.fixEmptyAndTrim(executablePath);
+        if (executable == null) {
+            return command;
+        }
+        if (command.isEmpty()) {
+            throw new IllegalStateException("Agent command is empty.");
+        }
+        List<String> resolved = new ArrayList<>(command);
+        resolved.set(0, executable);
+        return resolved;
     }
 
     static Map<String, String> parseEnvironmentVariables(String raw) {

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentConfiguration.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentConfiguration.java
@@ -12,6 +12,10 @@ public interface AiAgentConfiguration {
 
     String getWorkingDirectory();
 
+    default String getExecutablePath() {
+        return "";
+    }
+
     boolean isYoloMode();
 
     boolean isRequireApprovals();

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -59,9 +59,11 @@ final class AiAgentExecutor {
         String model = Util.replaceMacro(Util.fixNull(config.getModel()), env);
         String reasoningEffort = Util.replaceMacro(Util.fixNull(config.getReasoningEffort()), env);
         String workDirValue = Util.replaceMacro(Util.fixNull(config.getWorkingDirectory()), env);
+        String executablePath =
+                Util.replaceMacro(Util.fixNull(config.getExecutablePath()), env).trim();
         String commandOverride = Util.fixNull(config.getCommandOverride()).trim();
         AiAgentConfiguration resolvedConfig =
-                new ResolvedAiAgentConfiguration(config, model, reasoningEffort);
+                new ResolvedAiAgentConfiguration(config, model, reasoningEffort, executablePath);
         AiAgentTypeHandler agent = resolvedConfig.getAgent();
         agent.validateExecution(resolvedConfig);
         boolean manualApprovals =
@@ -135,7 +137,9 @@ final class AiAgentExecutor {
             if (!commandOverride.isEmpty()) {
                 agentCommand = List.of(commandOverride);
             } else if (acpExecution != null) {
-                agentCommand = acpExecution.getCommand();
+                agentCommand =
+                        AiAgentCommandFactory.applyExecutablePath(
+                                acpExecution.getCommand(), resolvedConfig.getExecutablePath());
             } else {
                 agentCommand = AiAgentCommandFactory.buildDefaultCommand(resolvedConfig, prompt);
             }
@@ -230,7 +234,7 @@ final class AiAgentExecutor {
                         if (disableInteractive) {
                             procStarter.stdin(InputStream.nullInputStream());
                         }
-                        Proc proc = procStarter.start();
+                        Proc proc = startProcess(procStarter, command.get(0));
                         outputHandler.attach(proc);
                         try {
                             exitCode = proc.join();
@@ -257,6 +261,9 @@ final class AiAgentExecutor {
                             ExecutionRegistry.unregister(run, invocationId);
                         }
                     }
+                }
+                if (exitCode == 127) {
+                    printCommandNotFoundGuidance(listener);
                 }
                 return exitCode;
             } catch (IOException | InterruptedException | RuntimeException | Error e) {
@@ -303,15 +310,16 @@ final class AiAgentExecutor {
             AiAgentTypeHandler.AcpExecutionSpec acpExecution)
             throws IOException, InterruptedException {
         Proc proc =
-                launcher.launch()
-                        .cmds(command)
-                        .pwd(runDirectory)
-                        .envs(procEnv)
-                        .readStdout()
-                        .readStderr()
-                        .writeStdin()
-                        .quiet(true)
-                        .start();
+                startProcess(
+                        launcher.launch()
+                                .cmds(command)
+                                .pwd(runDirectory)
+                                .envs(procEnv)
+                                .readStdout()
+                                .readStderr()
+                                .writeStdin()
+                                .quiet(true),
+                        command.get(0));
         outputHandler.attach(proc);
 
         InputStream stdout = proc.getStdout();
@@ -377,6 +385,31 @@ final class AiAgentExecutor {
         return thread;
     }
 
+    private static Proc startProcess(Launcher.ProcStarter procStarter, String executable)
+            throws IOException {
+        try {
+            return procStarter.start();
+        } catch (IOException e) {
+            throw new IOException(
+                    "Failed to start executable '"
+                            + executable
+                            + "'. Ensure it exists and is executable on the build node. Jenkins "
+                            + "does not load interactive shell startup files; configure Executable "
+                            + "path or update PATH in Additional environment variables or Setup "
+                            + "script.",
+                    e);
+        }
+    }
+
+    private static void printCommandNotFoundGuidance(TaskListener listener) {
+        listener.getLogger()
+                .println(
+                        "[ai-agent] Exit code 127 usually means a command was not found. Configure "
+                                + "Executable path or update PATH. Setup scripts without a shebang "
+                                + "run with /bin/sh -e; use '. file' there, or add #!/bin/bash or "
+                                + "#!/bin/zsh before using 'source'.");
+    }
+
     private static String buildCombinedScript(
             String setupScript,
             Map<String, String> shellEnvironment,
@@ -392,6 +425,7 @@ final class AiAgentExecutor {
                 sb.append('\n');
             }
         } else {
+            appendExecutableCheck(sb, agentCommand.get(0));
             sb.append("exec");
             for (String token : agentCommand) {
                 sb.append(' ').append(shellQuote(token));
@@ -399,6 +433,20 @@ final class AiAgentExecutor {
             sb.append('\n');
         }
         return sb.toString();
+    }
+
+    private static void appendExecutableCheck(StringBuilder sb, String executable) {
+        sb.append("if ! command -v ")
+                .append(shellQuote(executable))
+                .append(" >/dev/null 2>&1; then\n")
+                .append("  printf '%s\\n' ")
+                .append(
+                        shellQuote(
+                                "[ai-agent] Agent executable '"
+                                        + executable
+                                        + "' was not found. Configure Executable path or update "
+                                        + "PATH in Setup script."))
+                .append("\n  exit 127\nfi\n");
     }
 
     private static void appendShebangAwarePreamble(
@@ -498,12 +546,17 @@ final class AiAgentExecutor {
         private final AiAgentConfiguration delegate;
         private final String model;
         private final String reasoningEffort;
+        private final String executablePath;
 
         ResolvedAiAgentConfiguration(
-                AiAgentConfiguration delegate, String model, String reasoningEffort) {
+                AiAgentConfiguration delegate,
+                String model,
+                String reasoningEffort,
+                String executablePath) {
             this.delegate = delegate;
             this.model = model;
             this.reasoningEffort = reasoningEffort;
+            this.executablePath = executablePath;
         }
 
         @Override
@@ -529,6 +582,11 @@ final class AiAgentExecutor {
         @Override
         public String getWorkingDirectory() {
             return delegate.getWorkingDirectory();
+        }
+
+        @Override
+        public String getExecutablePath() {
+            return executablePath;
         }
 
         @Override

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly
@@ -18,6 +18,10 @@
     <f:textbox />
   </f:entry>
 
+  <f:entry title="Executable path (optional)" field="executablePath">
+    <f:textbox />
+  </f:entry>
+
   <f:entry title="Enable YOLO mode" field="yoloMode">
     <f:checkbox />
   </f:entry>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-executablePath.html
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-executablePath.html
@@ -1,0 +1,7 @@
+<div>
+  Overrides only the executable in the generated agent command while preserving its arguments.
+  Use an absolute path or a Jenkins environment variable, such as
+  <code>$HOME/.local/bin/codex</code>. When empty, Jenkins resolves the default executable from the
+  build node <code>PATH</code>. Interactive shell startup files are not loaded. Command override
+  takes precedence over this setting.
+</div>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-setupScript.html
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-setupScript.html
@@ -1,5 +1,7 @@
 <div>
   Runs before the agent command and shares the same shell session, so exported variables flow into
-  the agent process.
+  the agent process. Without a shebang, Jenkins uses <code>/bin/sh -e</code>, so use POSIX syntax
+  such as <code>. file</code>. Add <code>#!/bin/bash</code> or <code>#!/bin/zsh</code> before using
+  shell-specific syntax such as <code>source</code>.
   This is currently supported on Unix agents only.
 </div>

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
@@ -584,6 +584,91 @@ class AiAgentBuildExecutionTest {
 
     @Test
     @EnabledOnOs(OS.LINUX)
+    void executablePathRunsAgentOutsidePath(JenkinsRule jenkins) throws Exception {
+        File fakeBin =
+                installExecutable(
+                        jenkins,
+                        "custom-codex-bin",
+                        "custom-codex",
+                        "#!/bin/sh\nprintf '%s\\n' "
+                                + "'{\"type\":\"item.completed\",\"item\":{\"type\":\"agent_message\","
+                                + "\"text\":\"custom executable ran\"}}'\n");
+        String executable = new File(fakeBin, "custom-codex").getAbsolutePath();
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-custom-executable",
+                        b -> {
+                            b.setAgent(new CodexAgentHandler());
+                            b.setPrompt("test");
+                            b.setExecutablePath("${CUSTOM_AGENT_EXECUTABLE}");
+                        });
+        project.addProperty(
+                new ParametersDefinitionProperty(
+                        new StringParameterDefinition("CUSTOM_AGENT_EXECUTABLE", executable)));
+
+        FreeStyleBuild build =
+                project.scheduleBuild2(
+                                0,
+                                new ParametersAction(
+                                        new StringParameterValue(
+                                                "CUSTOM_AGENT_EXECUTABLE", executable)))
+                        .get();
+
+        jenkins.assertBuildStatusSuccess(build);
+        AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
+        assertNotNull(action);
+        assertTrue(
+                Files.readString(action.getRawLogFile().toPath())
+                        .contains("custom executable ran"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void missingExecutableReportsConfigurationGuidance(JenkinsRule jenkins) throws Exception {
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-missing-executable",
+                        b -> {
+                            b.setAgent(new CodexAgentHandler());
+                            b.setPrompt("test");
+                            b.setExecutablePath("/definitely/missing/ai-agent-codex");
+                        });
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        jenkins.assertBuildStatus(Result.FAILURE, build);
+        String log = jenkins.getLog(build);
+        assertTrue(log.contains("Failed to start executable '/definitely/missing/ai-agent-codex'"));
+        assertTrue(log.contains("configure Executable path or update PATH"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void setupScriptMissingExecutableReportsShellGuidance(JenkinsRule jenkins) throws Exception {
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-setup-missing-executable",
+                        b -> {
+                            b.setAgent(new CodexAgentHandler());
+                            b.setPrompt("test");
+                            b.setExecutablePath("definitely-missing-ai-agent-codex");
+                            b.setSetupScript("true");
+                        });
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+
+        jenkins.assertBuildStatus(Result.FAILURE, build);
+        String log = jenkins.getLog(build);
+        assertTrue(
+                log.contains("Agent executable 'definitely-missing-ai-agent-codex' was not found"));
+        assertTrue(log.contains("Setup scripts without a shebang run with /bin/sh -e"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
     void processLaunchFailureCompletesInvocationMetadata(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project =
                 newProject(
@@ -622,8 +707,8 @@ class AiAgentBuildExecutionTest {
                 .next()
                 .addCredentials(Domain.global(), credential);
         File fakeBin = installFakeOpenCode(jenkins, "fake-opencode-bin");
+        String executable = new File(fakeBin, "opencode").getAbsolutePath();
 
-        String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
         FreeStyleProject project =
                 newProject(
                         jenkins,
@@ -637,8 +722,8 @@ class AiAgentBuildExecutionTest {
                             b.setApiEnvVarName("FAKE_ACP_SECRET_INPUT");
                             b.setModel("test/provider-model");
                             b.setExtraArgs("--variant high --format json --pure");
+                            b.setExecutablePath(executable);
                             b.setSetupScript("cd \"${WORKSPACE}\"");
-                            b.setEnvironmentVariables("PATH=" + path);
                             b.setFailOnAgentError(true);
                         });
         DumbSlave agent = jenkins.createOnlineSlave();

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuilderConfigRoundTripTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuilderConfigRoundTripTest.java
@@ -32,6 +32,7 @@ class AiAgentBuilderConfigRoundTripTest {
         builder.setModel("gemini-2.5-pro");
         builder.setReasoningEffort("high");
         builder.setWorkingDirectory("src");
+        builder.setExecutablePath("/opt/agents/gemini");
         builder.setYoloMode(false);
         builder.setRequireApprovals(true);
         builder.setApprovalTimeoutSeconds(42);
@@ -52,6 +53,7 @@ class AiAgentBuilderConfigRoundTripTest {
         assertEquals("gemini-2.5-pro", reloaded.getModel());
         assertEquals("high", reloaded.getReasoningEffort());
         assertEquals("src", reloaded.getWorkingDirectory());
+        assertEquals("/opt/agents/gemini", reloaded.getExecutablePath());
         assertFalse(reloaded.isYoloMode());
         assertTrue(reloaded.isRequireApprovals());
         assertEquals(42, reloaded.getApprovalTimeoutSeconds());

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
@@ -322,13 +322,17 @@ class AiAgentCommandFactoryTest {
     void openCode_acpExecutionMapsRunOptionsToSessionConfig() {
         OpenCodeAgentHandler handler = new OpenCodeAgentHandler();
         AiAgentBuilder project = createProject(handler);
+        project.setExecutablePath("/opt/agents/opencode");
         project.setModel("opencode/provider-model");
         project.setReasoningEffort("high");
         project.setExtraArgs("--model override/model --variant=xhigh --format json --pure");
 
         AiAgentTypeHandler.AcpExecutionSpec execution = handler.buildAcpExecution(project);
 
-        assertEquals(List.of("opencode", "acp", "--pure"), execution.getCommand());
+        assertEquals(
+                List.of("/opt/agents/opencode", "acp", "--pure"),
+                AiAgentCommandFactory.applyExecutablePath(
+                        execution.getCommand(), project.getExecutablePath()));
         assertEquals("override/model", execution.getModel());
         assertEquals("xhigh", execution.getReasoningEffort());
     }
@@ -470,6 +474,18 @@ class AiAgentCommandFactoryTest {
     }
 
     // ======================== Model Without Value ========================
+
+    @Test
+    void allAgents_supportExecutablePathOverride() {
+        for (AiAgentTypeHandler handler : allHandlers()) {
+            AiAgentBuilder project = createProject(handler);
+            project.setExecutablePath("/opt/agents/" + handler.getId());
+
+            List<String> command = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+            assertEquals(project.getExecutablePath(), command.get(0));
+        }
+    }
 
     @Test
     void allAgents_noModelByDefault() {


### PR DESCRIPTION
## Summary

Makes agent executable selection explicit for Jenkins services and build nodes whose `PATH` differs from interactive shells.

## Changes

- adds optional **Executable path** configuration with Jenkins environment-variable expansion
- replaces only argv[0], preserving generated model, reasoning, approval, safety, and extra arguments
- applies same behavior to standard execution and OpenCode ACP
- reports actionable guidance for direct launch failures and exit code 127
- documents that setup scripts without shebangs run under `/bin/sh -e`, where `. file` is portable and `source` requires a Bash or Zsh shebang
- preserves existing jobs through empty defaults and deserialization normalization

## Testing

- `mvn -B -ntp clean verify` (216 tests, 0 failures, 1 skipped; SpotBugs clean; formatter clean; HPI built)
- focused execution/config/command suite (65 tests)
- `npm test` (7 tests)
- JenkinsRule coverage for an environment-expanded executable outside `PATH`, missing executable diagnostics, setup-shell diagnostics, OpenCode ACP, and configuration round trip
- independent verification: PASS

## Validation limits

No real Windows executor was available. Existing Windows command construction remains unchanged; GitHub CI provides fresh Java 17/21 validation.