### PR TITLE
[codex] Show command input in execution results

### DIFF
--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentLogParser.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentLogParser.java
@@ -465,13 +465,23 @@ public final class AiAgentLogParser {
 
         public static ParsedLine toolResult(
                 long id, String toolName, String toolOutput, String rawDetails, String toolCallId) {
+            return toolResult(id, toolName, "", toolOutput, rawDetails, toolCallId);
+        }
+
+        public static ParsedLine toolResult(
+                long id,
+                String toolName,
+                String toolInput,
+                String toolOutput,
+                String rawDetails,
+                String toolCallId) {
             String displayName = toolName.isEmpty() ? "Tool" : toolName;
             return new ParsedLine(
                     id,
                     "tool_result",
                     displayName,
                     "",
-                    "",
+                    toolInput,
                     toolOutput,
                     toolName,
                     rawDetails,

--- a/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexLogFormat.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexLogFormat.java
@@ -76,11 +76,11 @@ public final class CodexLogFormat implements AiAgentLogFormat {
                 return AiAgentLogParser.ParsedLine.toolCall(
                         lineNumber, toolName, toolInput, rawDetails, toolCallId);
             }
+            String toolInput = itemType.contains("command_execution") ? extractToolInput(item) : "";
             String toolOutput = extractToolOutput(item);
-            if (toolOutput.isEmpty()) {
+            if (toolInput.isEmpty() && toolOutput.isEmpty()) {
                 return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
             }
-            String toolInput = itemType.contains("command_execution") ? extractToolInput(item) : "";
             return AiAgentLogParser.ParsedLine.toolResult(
                     lineNumber, toolName, toolInput, toolOutput, rawDetails, toolCallId);
         }

--- a/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexLogFormat.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexLogFormat.java
@@ -80,8 +80,9 @@ public final class CodexLogFormat implements AiAgentLogFormat {
             if (toolOutput.isEmpty()) {
                 return AiAgentLogParser.ParsedLine.raw(lineNumber, "");
             }
+            String toolInput = itemType.contains("command_execution") ? extractToolInput(item) : "";
             return AiAgentLogParser.ParsedLine.toolResult(
-                    lineNumber, toolName, toolOutput, rawDetails, toolCallId);
+                    lineNumber, toolName, toolInput, toolOutput, rawDetails, toolCallId);
         }
         String itemText = LogFormatUtils.extractText(item);
         if (itemText.isEmpty()) {

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/conversation.jelly
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/conversation.jelly
@@ -110,18 +110,27 @@
                           <summary class="ai-tool-header ai-details-summary">
                             <span class="ai-badge ai-badge-tool_result">OUTPUT</span>
                             <span class="ai-tool-label">${ev.label}</span>
-                            <j:if test="${ev.toolOutput != ''}">
-                              <span class="ai-tool-input-preview ai-tool-output-preview">
-                                <j:choose>
-                                  <j:when test="${ev.toolOutput.length() > 80}">
-                                    ${ev.toolOutput.substring(0, 80)}...
-                                  </j:when>
-                                  <j:otherwise>${ev.toolOutput}</j:otherwise>
-                                </j:choose>
-                              </span>
-                            </j:if>
+                            <j:choose>
+                              <j:when test="${ev.toolInput != ''}">
+                                <span class="ai-tool-input-preview">${ev.toolInput}</span>
+                              </j:when>
+                              <j:when test="${ev.toolOutput != ''}">
+                                <span class="ai-tool-input-preview ai-tool-output-preview">
+                                  <j:choose>
+                                    <j:when test="${ev.toolOutput.length() > 80}">
+                                      ${ev.toolOutput.substring(0, 80)}...
+                                    </j:when>
+                                    <j:otherwise>${ev.toolOutput}</j:otherwise>
+                                  </j:choose>
+                                </span>
+                              </j:when>
+                            </j:choose>
                           </summary>
                           <div class="ai-tool-body">
+                            <j:if test="${ev.toolInput != ''}">
+                              <div class="ai-tool-section-label">Input</div>
+                              <div class="ai-tool-section-content">${ev.toolInput}</div>
+                            </j:if>
                             <j:if test="${ev.toolOutput != ''}">
                               <div class="ai-tool-section-label">Output</div>
                               <div class="ai-tool-section-content">${ev.toolOutput}</div>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary.jelly
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary.jelly
@@ -119,18 +119,27 @@
                             <summary class="ai-tool-header ai-details-summary">
                               <span class="ai-badge ai-badge-tool_result">OUTPUT</span>
                               <span class="ai-tool-label">${ev.label}</span>
-                              <j:if test="${ev.toolOutput != ''}">
-                                <span class="ai-tool-input-preview ai-tool-output-preview">
-                                  <j:choose>
-                                    <j:when test="${ev.toolOutput.length() > 80}">
-                                      ${ev.toolOutput.substring(0, 80)}...
-                                    </j:when>
-                                    <j:otherwise>${ev.toolOutput}</j:otherwise>
-                                  </j:choose>
-                                </span>
-                              </j:if>
+                              <j:choose>
+                                <j:when test="${ev.toolInput != ''}">
+                                  <span class="ai-tool-input-preview">${ev.toolInput}</span>
+                                </j:when>
+                                <j:when test="${ev.toolOutput != ''}">
+                                  <span class="ai-tool-input-preview ai-tool-output-preview">
+                                    <j:choose>
+                                      <j:when test="${ev.toolOutput.length() > 80}">
+                                        ${ev.toolOutput.substring(0, 80)}...
+                                      </j:when>
+                                      <j:otherwise>${ev.toolOutput}</j:otherwise>
+                                    </j:choose>
+                                  </span>
+                                </j:when>
+                              </j:choose>
                             </summary>
                             <div class="ai-tool-body">
+                              <j:if test="${ev.toolInput != ''}">
+                                <div class="ai-tool-section-label">Input</div>
+                                <div class="ai-tool-section-content">${ev.toolInput}</div>
+                              </j:if>
                               <j:if test="${ev.toolOutput != ''}">
                                 <div class="ai-tool-section-label">Output</div>
                                 <div class="ai-tool-section-content">${ev.toolOutput}</div>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary_resources.js
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentRunAction/summary_resources.js
@@ -226,11 +226,17 @@
       html += '<summary class="ai-tool-header ai-details-summary">';
       html += '<span class="ai-badge ai-badge-tool_result">OUTPUT</span>';
       html += '<span class="ai-tool-label">' + esc(ev.label) + '</span>';
-      if (ev.toolOutput) {
+      if (ev.toolInput) {
+        html += '<span class="ai-tool-input-preview">' + excerpt(ev.toolInput, 120) + '</span>';
+      } else if (ev.toolOutput) {
         html += '<span class="ai-tool-input-preview ai-tool-output-preview">' + excerpt(ev.toolOutput, 80) + '</span>';
       }
       html += '</summary>';
       html += '<div class="ai-tool-body">';
+      if (ev.toolInput) {
+        html += '<div class="ai-tool-section-label">Input</div>';
+        html += '<div class="ai-tool-section-content">' + esc(ev.toolInput) + '</div>';
+      }
       if (ev.toolOutput) {
         html += '<div class="ai-tool-section-label">Output</div>';
         html += '<div class="ai-tool-section-content">' + esc(ev.toolOutput) + '</div>';

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentLogParserTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentLogParserTest.java
@@ -213,7 +213,7 @@ class AiAgentLogParserTest {
                 cats.contains("tool_result"),
                 "Should have tool_result (command_execution completed)");
         assertTrue(cats.contains("assistant"), "Should have assistant (agent_message)");
-        assertEquals(16, events.size(), "Current Codex fixture should keep 16 visible events");
+        assertEquals(17, events.size(), "Current Codex fixture should keep 17 visible events");
     }
 
     @Test
@@ -234,13 +234,13 @@ class AiAgentLogParserTest {
     }
 
     @Test
-    void codexConversation_hidesCompletionsWithoutOutput() throws IOException {
+    void codexConversation_showsCommandCompletionsWithoutOutput() throws IOException {
         List<AiAgentLogParser.EventView> events =
                 parseFixture("codex-conversation.jsonl", CodexLogFormat.INSTANCE);
         long started = events.stream().filter(e -> "tool_call".equals(e.getCategory())).count();
         long completed = events.stream().filter(e -> "tool_result".equals(e.getCategory())).count();
         assertEquals(6, started, "Fixture should keep command and MCP starts visible");
-        assertEquals(5, completed, "Empty command completion should not render a result");
+        assertEquals(6, completed, "Command completions should render even without output");
     }
 
     @Test
@@ -252,7 +252,7 @@ class AiAgentLogParserTest {
                         .filter(e -> "tool_result".equals(e.getCategory()))
                         .collect(Collectors.toList());
 
-        assertEquals(5, toolResults.size(), "Should have 5 visible tool results");
+        assertEquals(6, toolResults.size(), "Should have 6 visible tool results");
         assertTrue(toolResults.stream().anyMatch(e -> e.getToolOutput().contains("README.md")));
         assertTrue(toolResults.stream().anyMatch(e -> e.getToolOutput().contains("sample-plugin")));
         assertTrue(toolResults.stream().anyMatch(e -> e.getToolOutput().contains("1 failed")));
@@ -264,10 +264,17 @@ class AiAgentLogParserTest {
                 toolResults.stream()
                         .filter(e -> "bash".equals(e.getLabel()))
                         .collect(Collectors.toList());
-        assertEquals(4, commandResults.size(), "Should have 4 completed commands with output");
+        assertEquals(5, commandResults.size(), "Should have 5 completed commands");
         assertTrue(
                 commandResults.stream().allMatch(e -> !e.getToolInput().isEmpty()),
                 "Completed Codex commands should preserve their command input");
+        assertTrue(
+                commandResults.stream()
+                        .anyMatch(
+                                e ->
+                                        e.getToolInput().contains("mvn -q")
+                                                && e.getToolOutput().isEmpty()),
+                "Successful silent commands should render their command input");
         AiAgentLogParser.EventView mcpResult =
                 toolResults.stream()
                         .filter(e -> "list_mcp_resources".equals(e.getLabel()))
@@ -792,7 +799,7 @@ class AiAgentLogParserTest {
     void codexConversation_hasCorrectEventCount() throws IOException {
         List<AiAgentLogParser.EventView> events =
                 parseFixture("codex-conversation.jsonl", CodexLogFormat.INSTANCE);
-        assertEquals(16, events.size(), "Current Codex fixture should produce 16 visible events");
+        assertEquals(17, events.size(), "Current Codex fixture should produce 17 visible events");
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentLogParserTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentLogParserTest.java
@@ -213,7 +213,7 @@ class AiAgentLogParserTest {
                 cats.contains("tool_result"),
                 "Should have tool_result (command_execution completed)");
         assertTrue(cats.contains("assistant"), "Should have assistant (agent_message)");
-        assertEquals(11, events.size(), "Current Codex fixture should keep 11 visible events");
+        assertEquals(16, events.size(), "Current Codex fixture should keep 16 visible events");
     }
 
     @Test
@@ -225,10 +225,11 @@ class AiAgentLogParserTest {
                         .filter(e -> "tool_call".equals(e.getCategory()))
                         .collect(Collectors.toList());
 
-        assertEquals(4, toolCalls.size(), "Should have 3 command starts and 1 MCP tool call");
+        assertEquals(6, toolCalls.size(), "Should have 5 command starts and 1 MCP tool call");
         assertTrue(toolCalls.stream().anyMatch(e -> e.getToolInput().contains("rg --files")));
         assertTrue(toolCalls.stream().anyMatch(e -> e.getToolInput().contains("sed -n")));
         assertTrue(toolCalls.stream().anyMatch(e -> e.getToolInput().contains("mvn -q")));
+        assertTrue(toolCalls.stream().anyMatch(e -> e.getToolInput().contains("npm test")));
         assertTrue(toolCalls.stream().anyMatch(e -> e.getToolInput().contains("server")));
     }
 
@@ -238,8 +239,8 @@ class AiAgentLogParserTest {
                 parseFixture("codex-conversation.jsonl", CodexLogFormat.INSTANCE);
         long started = events.stream().filter(e -> "tool_call".equals(e.getCategory())).count();
         long completed = events.stream().filter(e -> "tool_result".equals(e.getCategory())).count();
-        assertEquals(4, started, "Fixture should keep command and MCP starts visible");
-        assertEquals(3, completed, "Empty command completion should not render a result");
+        assertEquals(6, started, "Fixture should keep command and MCP starts visible");
+        assertEquals(5, completed, "Empty command completion should not render a result");
     }
 
     @Test
@@ -251,12 +252,30 @@ class AiAgentLogParserTest {
                         .filter(e -> "tool_result".equals(e.getCategory()))
                         .collect(Collectors.toList());
 
-        assertEquals(3, toolResults.size(), "Should have 3 visible tool results");
+        assertEquals(5, toolResults.size(), "Should have 5 visible tool results");
         assertTrue(toolResults.stream().anyMatch(e -> e.getToolOutput().contains("README.md")));
         assertTrue(toolResults.stream().anyMatch(e -> e.getToolOutput().contains("sample-plugin")));
+        assertTrue(toolResults.stream().anyMatch(e -> e.getToolOutput().contains("1 failed")));
+        assertTrue(toolResults.stream().anyMatch(e -> e.getToolOutput().contains("8 passed")));
         assertTrue(
                 toolResults.stream()
                         .anyMatch(e -> e.getToolOutput().contains("No external resources")));
+        List<AiAgentLogParser.EventView> commandResults =
+                toolResults.stream()
+                        .filter(e -> "bash".equals(e.getLabel()))
+                        .collect(Collectors.toList());
+        assertEquals(4, commandResults.size(), "Should have 4 completed commands with output");
+        assertTrue(
+                commandResults.stream().allMatch(e -> !e.getToolInput().isEmpty()),
+                "Completed Codex commands should preserve their command input");
+        AiAgentLogParser.EventView mcpResult =
+                toolResults.stream()
+                        .filter(e -> "list_mcp_resources".equals(e.getLabel()))
+                        .findFirst()
+                        .orElseThrow();
+        assertTrue(
+                mcpResult.getToolInput().isEmpty(),
+                "MCP result text should not be duplicated as tool input");
     }
 
     // ======================== Cursor Agent Tests ========================
@@ -525,6 +544,7 @@ class AiAgentLogParserTest {
         AiAgentLogParser.ParsedLine line =
                 AiAgentLogParser.parseLine(1, json, CodexLogFormat.INSTANCE);
         assertEquals("tool_result", line.toEventView().getCategory());
+        assertEquals("ls -la", line.toEventView().getToolInput());
         assertEquals("README.md\npom.xml", line.toEventView().getToolOutput());
     }
 
@@ -772,7 +792,7 @@ class AiAgentLogParserTest {
     void codexConversation_hasCorrectEventCount() throws IOException {
         List<AiAgentLogParser.EventView> events =
                 parseFixture("codex-conversation.jsonl", CodexLogFormat.INSTANCE);
-        assertEquals(11, events.size(), "Current Codex fixture should produce 11 visible events");
+        assertEquals(16, events.size(), "Current Codex fixture should produce 16 visible events");
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRecordedConversationTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRecordedConversationTest.java
@@ -113,17 +113,20 @@ class AiAgentRecordedConversationTest {
         assertTrue(cats.contains("tool_call"), "Should have tool_call");
         assertTrue(cats.contains("tool_result"), "Should have tool_result");
         assertTrue(cats.contains("assistant"), "Should have assistant");
-        assertEquals(16, events.size(), "Current Codex fixture should render 16 visible events");
+        assertEquals(17, events.size(), "Current Codex fixture should render 17 visible events");
         List<AiAgentLogParser.EventView> completedCommands =
                 events.stream()
                         .filter(e -> "tool_result".equals(e.getCategory()))
                         .filter(e -> "bash".equals(e.getLabel()))
                         .collect(Collectors.toList());
-        assertEquals(4, completedCommands.size());
+        assertEquals(5, completedCommands.size());
         assertTrue(
-                completedCommands.stream()
-                        .allMatch(e -> !e.getToolInput().isEmpty() && !e.getToolOutput().isEmpty()),
-                "Completed Codex commands should expose input and output");
+                completedCommands.stream().allMatch(e -> !e.getToolInput().isEmpty()),
+                "Completed Codex commands should expose input");
+        assertEquals(
+                1,
+                completedCommands.stream().filter(e -> e.getToolOutput().isEmpty()).count(),
+                "Silent command completion should remain visible without output");
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRecordedConversationTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRecordedConversationTest.java
@@ -113,7 +113,17 @@ class AiAgentRecordedConversationTest {
         assertTrue(cats.contains("tool_call"), "Should have tool_call");
         assertTrue(cats.contains("tool_result"), "Should have tool_result");
         assertTrue(cats.contains("assistant"), "Should have assistant");
-        assertEquals(11, events.size(), "Current Codex fixture should render 11 visible events");
+        assertEquals(16, events.size(), "Current Codex fixture should render 16 visible events");
+        List<AiAgentLogParser.EventView> completedCommands =
+                events.stream()
+                        .filter(e -> "tool_result".equals(e.getCategory()))
+                        .filter(e -> "bash".equals(e.getLabel()))
+                        .collect(Collectors.toList());
+        assertEquals(4, completedCommands.size());
+        assertTrue(
+                completedCommands.stream()
+                        .allMatch(e -> !e.getToolInput().isEmpty() && !e.getToolOutput().isEmpty()),
+                "Completed Codex commands should expose input and output");
     }
 
     @Test

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRunActionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentRunActionTest.java
@@ -10,11 +10,13 @@ import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.security.csrf.DefaultCrumbIssuer;
 
+import io.jenkins.plugins.aiagentjob.codex.CodexAgentHandler;
 import io.jenkins.plugins.aiagentjob.geminicli.GeminiCliAgentHandler;
 
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
+import org.htmlunit.html.HtmlElement;
 import org.htmlunit.html.HtmlPage;
 import org.htmlunit.html.HtmlScript;
 import org.junit.jupiter.api.Test;
@@ -350,6 +352,43 @@ class AiAgentRunActionTest {
         assertTrue(text.contains("AI Agent Conversation #1"));
         assertFalse(text.contains("Explain this repository in detail"));
         assertTrue(text.contains("Raw Log"));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void conversationPage_showsCompletedCodexCommandInputAndOutput(JenkinsRule jenkins)
+            throws Exception {
+        String script = buildCatScript("codex-conversation.jsonl");
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "test-codex-command-details",
+                        b -> {
+                            b.setAgent(new CodexAgentHandler());
+                            b.setCommandOverride(script);
+                        });
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+
+        JenkinsRule.WebClient wc = jenkins.createWebClient();
+        wc.getOptions().setJavaScriptEnabled(false);
+        wc.getOptions().setCssEnabled(false);
+        HtmlPage page = wc.goTo(build.getUrl() + "ai-agent/conversation?invocation=1");
+        HtmlElement completedCommand =
+                page.getFirstByXPath(
+                        "//details[.//span[contains(@class, 'ai-badge-tool_result')]"
+                                + " and .//div[contains(., 'Tests: 8 passed')]]");
+
+        assertNotNull(completedCommand);
+        List<HtmlElement> labels =
+                completedCommand.getByXPath(".//div[contains(@class, 'ai-tool-section-label')]");
+        List<HtmlElement> contents =
+                completedCommand.getByXPath(".//div[contains(@class, 'ai-tool-section-content')]");
+        assertEquals(
+                List.of("Input", "Output"),
+                labels.stream().map(HtmlElement::getTextContent).toList());
+        assertEquals(2, contents.size());
+        assertTrue(contents.get(0).getTextContent().contains("npm test -- --runInBand"));
+        assertTrue(contents.get(1).getTextContent().contains("Tests: 8 passed"));
     }
 
     @Test

--- a/src/test/js/summary_resources.test.js
+++ b/src/test/js/summary_resources.test.js
@@ -121,3 +121,19 @@ test('thinking delta appends text only to latest thinking event', function () {
     content: ' ignored'
   }), false);
 });
+
+test('completed tool event renders both input and output when expanded', function () {
+  const container = document.createElement('div');
+  container.insertAdjacentHTML('beforeend', renderEvent({
+    category: 'tool_result',
+    label: 'bash',
+    toolInput: 'check-project --mode focused',
+    toolOutput: '8 checks passed'
+  }));
+
+  const sections = container.querySelectorAll('.ai-tool-section-content');
+  assert.equal(sections.length, 2);
+  assert.equal(sections[0].textContent, 'check-project --mode focused');
+  assert.equal(sections[1].textContent, '8 checks passed');
+  assert.match(container.querySelector('summary').textContent, /check-project --mode focused/);
+});

--- a/src/test/resources/io/jenkins/plugins/aiagentjob/fixtures/codex-conversation.jsonl
+++ b/src/test/resources/io/jenkins/plugins/aiagentjob/fixtures/codex-conversation.jsonl
@@ -8,9 +8,16 @@
 {"type":"item.completed","item":{"id":"item_3","type":"command_execution","command":"/usr/bin/zsh -lc 'sed -n '\\''1,80p'\\'' pom.xml'","aggregated_output":"<project>\n  <artifactId>sample-plugin</artifactId>\n</project>\n","exit_code":0,"status":"completed"}}
 {"type":"item.started","item":{"id":"item_4","type":"command_execution","command":"/usr/bin/zsh -lc 'mvn -q -DskipTests package'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
 {"type":"item.completed","item":{"id":"item_4","type":"command_execution","command":"/usr/bin/zsh -lc 'mvn -q -DskipTests package'","aggregated_output":"","exit_code":0,"status":"completed"}}
-{"type":"item.completed","item":{"id":"item_5","type":"reasoning","status":"completed","text":"Build metadata and targeted package step look consistent. Need include tool evidence in final answer."}}
-{"type":"item.started","item":{"id":"item_6","type":"mcp_tool_call","status":"in_progress","name":"list_mcp_resources","arguments":{"server":"docs"}}}
-{"type":"item.completed","item":{"id":"item_6","type":"mcp_tool_call","status":"completed","name":"list_mcp_resources","result":{"text":"No external resources used for this sanitized fixture."}}}
-{"type":"item.started","item":{"id":"item_7","type":"agent_message","status":"in_progress","text":""}}
-{"type":"item.completed","item":{"id":"item_7","type":"agent_message","text":"Validated sanitized project metadata and package command. No private paths, tokens, or user data were included."}}
-{"type":"turn.completed","usage":{"input_tokens":42581,"cached_input_tokens":30976,"output_tokens":108,"reasoning_output_tokens":49}}
+{"type":"item.started","item":{"id":"item_5","type":"command_execution","command":"/usr/bin/zsh -lc 'npm test -- --runInBand'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_5","type":"command_execution","command":"/usr/bin/zsh -lc 'npm test -- --runInBand'","aggregated_output":"FAIL test/config.test.js\nExpected: enabled\nReceived: disabled\nTests: 1 failed, 7 passed\n","exit_code":1,"status":"failed"}}
+{"type":"item.completed","item":{"id":"item_6","type":"agent_message","text":"Focused validation exposed a synthetic configuration mismatch. I will update the fixture project and rerun the same command."}}
+{"type":"item.started","item":{"id":"item_7","type":"file_change","changes":[{"path":"src/config.js","kind":"update"}],"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_7","type":"file_change","changes":[{"path":"src/config.js","kind":"update"}],"status":"completed"}}
+{"type":"item.started","item":{"id":"item_8","type":"command_execution","command":"/usr/bin/zsh -lc 'npm test -- --runInBand'","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_8","type":"command_execution","command":"/usr/bin/zsh -lc 'npm test -- --runInBand'","aggregated_output":"PASS test/config.test.js\nTests: 8 passed\n","exit_code":0,"status":"completed"}}
+{"type":"item.completed","item":{"id":"item_9","type":"reasoning","status":"completed","text":"Build metadata and focused checks are consistent. Need include tool evidence in final answer."}}
+{"type":"item.started","item":{"id":"item_10","type":"mcp_tool_call","status":"in_progress","name":"list_mcp_resources","arguments":{"server":"docs"}}}
+{"type":"item.completed","item":{"id":"item_10","type":"mcp_tool_call","status":"completed","name":"list_mcp_resources","result":{"text":"No external resources used for this sanitized fixture."}}}
+{"type":"item.started","item":{"id":"item_11","type":"agent_message","status":"in_progress","text":""}}
+{"type":"item.completed","item":{"id":"item_11","type":"agent_message","text":"Validated sanitized project metadata and focused checks. No private paths, tokens, or user data were included."}}
+{"type":"turn.completed","usage":{"input_tokens":1200,"cached_input_tokens":800,"output_tokens":120,"reasoning_output_tokens":40}}


### PR DESCRIPTION
## Summary

Shows Codex command input alongside aggregated output in completed execution details, including completed commands with no output.

## Changes

- preserves the repeated `command` field on completed Codex `command_execution` events
- previews the command in completed output-card headers
- renders separate Input and Output sections in build summaries, full conversation pages, and progressive live updates
- keeps silent completed commands visible when input exists
- keeps MCP result text out of the input field
- expands the Codex fixture with a fully synthetic fail/fix trajectory containing no production paths, hosts, identifiers, commands, or output

## Testing

- `mvn -B -ntp clean verify` (230 tests, 0 failures, 1 skipped; SpotBugs clean; formatter clean; HPI built)
- `npm test` (8 DOM/JavaScript tests plus syntax check)
- focused parser, recorded-trajectory, and Jenkins page coverage
- JenkinsRule DOM assertion confirms rendered completed command contains both Input and Output sections
- independent source/privacy review: PASS

## Validation limits

No manual browser session was used. JenkinsRule rendered the real Jelly page, and the JavaScript renderer ran against a DOM implementation.