### PR TITLE
[core] Support model reasoning effort suffixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Build page showing a Cursor Agent conversation with tool calls, markdown-rendere
 2. Add/configure the **Run AI Agent** build step:
    - **Agent Type** — select the coding agent to run.
    - **Prompt** — the task to send to the agent.
-   - **Model** — optional model override (e.g., `claude-sonnet-4`).
-   - **Reasoning effort** — optional effort override for supported agents (e.g., `high`, `xhigh`).
+   - **Model** — optional model override. Codex, Claude Code, and OpenCode accept `model:effort` shorthand (e.g., `gpt-5.6-sol:xhigh`).
+   - **Reasoning effort** — optional effort override for supported agents (e.g., `high`, `xhigh`); takes precedence over the model suffix.
    - **YOLO mode** — skip confirmation prompts in the agent.
    - **Approvals** — require human approval for tool calls.
    - **Setup script** — shell commands to run before the agent (install tools, source dotfiles, configure runtime variables).
@@ -126,8 +126,8 @@ The plugin injects these variables into every build:
 | Variable | Description |
 |----------|-------------|
 | `AI_AGENT_PROMPT` | The configured prompt text |
-| `AI_AGENT_MODEL` | The configured model name |
-| `AI_AGENT_REASONING_EFFORT` | The configured reasoning effort |
+| `AI_AGENT_MODEL` | The field-derived model name, without a recognized reasoning-effort suffix |
+| `AI_AGENT_REASONING_EFFORT` | The field-derived reasoning effort |
 
 ### Executable Path
 
@@ -195,6 +195,19 @@ The **Reasoning effort** field is passed only to agents with verified CLI suppor
 - OpenCode: `--variant <value>`
 
 Gemini CLI and Cursor Agent currently ignore the field in the built-in command template.
+
+For supported agents, the **Model** field also accepts `model:effort` shorthand. For example,
+`gpt-5.6-sol:xhigh` resolves to model `gpt-5.6-sol` and reasoning effort `xhigh`. Recognized
+suffixes depend on the selected agent: Codex accepts `low`, `medium`, `high`, `xhigh`, `max`,
+and `ultra`; Claude Code accepts `low`, `medium`, `high`, `xhigh`, and `max`; OpenCode also
+accepts `minimal` and provider-defined support still determines whether a variant is available.
+Other suffixes remain part of the model identifier. Use a double colon to keep a recognized
+suffix literal, such as `provider/model::high` for model `provider/model:high`. A value in
+**Reasoning effort** overrides the shorthand suffix.
+
+**Extra CLI args** can override generated model or effort options. The `AI_AGENT_*` variables
+and build metadata continue to describe the fields after shorthand resolution, before those
+later command-line overrides.
 
 ### Credential Injection
 

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -62,6 +62,10 @@ final class AiAgentExecutor {
         String executablePath =
                 Util.replaceMacro(Util.fixNull(config.getExecutablePath()), env).trim();
         String commandOverride = Util.fixNull(config.getCommandOverride()).trim();
+        AiAgentTypeHandler.ModelSelection modelSelection =
+                config.getAgent().resolveModelSelection(model, reasoningEffort);
+        model = modelSelection.getModel();
+        reasoningEffort = modelSelection.getReasoningEffort();
         AiAgentConfiguration resolvedConfig =
                 new ResolvedAiAgentConfiguration(config, model, reasoningEffort, executablePath);
         AiAgentTypeHandler agent = resolvedConfig.getAgent();

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -56,24 +56,28 @@ final class AiAgentExecutor {
         EnvVars env = new EnvVars(stepEnv);
 
         String prompt = Util.replaceMacro(Util.fixNull(config.getPrompt()), env);
-        String model = Util.replaceMacro(Util.fixNull(config.getModel()), env);
-        String reasoningEffort = Util.replaceMacro(Util.fixNull(config.getReasoningEffort()), env);
+        String expandedModel = Util.replaceMacro(Util.fixNull(config.getModel()), env);
+        String expandedReasoningEffort =
+                Util.replaceMacro(Util.fixNull(config.getReasoningEffort()), env);
         String workDirValue = Util.replaceMacro(Util.fixNull(config.getWorkingDirectory()), env);
         String executablePath =
                 Util.replaceMacro(Util.fixNull(config.getExecutablePath()), env).trim();
         String commandOverride = Util.fixNull(config.getCommandOverride()).trim();
+        AiAgentTypeHandler agent = config.getAgent();
         AiAgentTypeHandler.ModelSelection modelSelection =
-                config.getAgent().resolveModelSelection(model, reasoningEffort);
-        model = modelSelection.getModel();
-        reasoningEffort = modelSelection.getReasoningEffort();
+                agent.resolveModelSelection(expandedModel, expandedReasoningEffort);
+        String model = modelSelection.getModel();
+        String reasoningEffort = modelSelection.getReasoningEffort();
+        AiAgentConfiguration commandConfig =
+                new ResolvedAiAgentConfiguration(
+                        config, expandedModel, expandedReasoningEffort, executablePath);
         AiAgentConfiguration resolvedConfig =
                 new ResolvedAiAgentConfiguration(config, model, reasoningEffort, executablePath);
-        AiAgentTypeHandler agent = resolvedConfig.getAgent();
         agent.validateExecution(resolvedConfig);
         boolean manualApprovals =
                 resolvedConfig.isRequireApprovals() && !resolvedConfig.isYoloMode();
         AiAgentTypeHandler.AcpExecutionSpec acpExecution =
-                manualApprovals ? agent.buildAcpExecution(resolvedConfig) : null;
+                manualApprovals ? agent.buildAcpExecution(commandConfig) : null;
         if (manualApprovals && acpExecution == null) {
             throw new IllegalArgumentException(
                     "Manual approvals require an ACP-capable agent command.");
@@ -145,7 +149,7 @@ final class AiAgentExecutor {
                         AiAgentCommandFactory.applyExecutablePath(
                                 acpExecution.getCommand(), resolvedConfig.getExecutablePath());
             } else {
-                agentCommand = AiAgentCommandFactory.buildDefaultCommand(resolvedConfig, prompt);
+                agentCommand = AiAgentCommandFactory.buildDefaultCommand(commandConfig, prompt);
             }
 
             boolean needsShellEnvironmentBootstrap =

--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentTypeHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentTypeHandler.java
@@ -2,11 +2,13 @@ package io.jenkins.plugins.aiagentjob;
 
 import hudson.ExtensionPoint;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.TaskListener;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Describable extension point for an AI agent implementation.
@@ -54,6 +56,36 @@ public abstract class AiAgentTypeHandler extends AbstractDescribableImpl<AiAgent
         return false;
     }
 
+    /** Reasoning efforts recognized when appended to a model identifier. */
+    protected Set<String> getSupportedReasoningEfforts() {
+        return Set.of();
+    }
+
+    /** Resolves the model and optional {@code model:effort} shorthand for this handler. */
+    public final ModelSelection resolveModelSelection(
+            String configuredModel, String configuredReasoningEffort) {
+        String model = Util.fixNull(configuredModel).trim();
+        String reasoningEffort = Util.fixNull(configuredReasoningEffort).trim();
+        Set<String> supportedEfforts = getSupportedReasoningEfforts();
+        if (!supportedEfforts.isEmpty()) {
+            int separator = model.lastIndexOf(':');
+            if (separator > 0 && separator < model.length() - 1) {
+                String suffix = model.substring(separator + 1);
+                if (supportedEfforts.contains(suffix)) {
+                    if (model.charAt(separator - 1) == ':') {
+                        model = model.substring(0, separator - 1) + model.substring(separator);
+                    } else {
+                        model = model.substring(0, separator);
+                        if (reasoningEffort.isEmpty()) {
+                            reasoningEffort = suffix;
+                        }
+                    }
+                }
+            }
+        }
+        return new ModelSelection(model, reasoningEffort);
+    }
+
     public abstract List<String> buildDefaultCommand(AiAgentConfiguration config, String prompt);
 
     /**
@@ -86,6 +118,25 @@ public abstract class AiAgentTypeHandler extends AbstractDescribableImpl<AiAgent
      * false} for any JSON it does not recognise, so the shared extractor handles it as a fallback.
      */
     public abstract AiAgentStatsExtractor getStatsExtractor();
+
+    /** Immutable runtime model and reasoning-effort selection. */
+    public static final class ModelSelection {
+        private final String model;
+        private final String reasoningEffort;
+
+        private ModelSelection(String model, String reasoningEffort) {
+            this.model = model;
+            this.reasoningEffort = reasoningEffort;
+        }
+
+        public String getModel() {
+            return model;
+        }
+
+        public String getReasoningEffort() {
+            return reasoningEffort;
+        }
+    }
 
     /** Immutable settings for an Agent Client Protocol execution. */
     public static final class AcpExecutionSpec {

--- a/src/main/java/io/jenkins/plugins/aiagentjob/claudecode/ClaudeCodeAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/claudecode/ClaudeCodeAgentHandler.java
@@ -14,8 +14,12 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public final class ClaudeCodeAgentHandler extends AiAgentTypeHandler {
+    private static final Set<String> REASONING_EFFORTS =
+            Set.of("low", "medium", "high", "xhigh", "max");
+
     @DataBoundConstructor
     public ClaudeCodeAgentHandler() {}
 
@@ -27,6 +31,11 @@ public final class ClaudeCodeAgentHandler extends AiAgentTypeHandler {
     @Override
     public String getDefaultApiKeyEnvVar() {
         return "ANTHROPIC_API_KEY";
+    }
+
+    @Override
+    protected Set<String> getSupportedReasoningEfforts() {
+        return REASONING_EFFORTS;
     }
 
     @Override
@@ -42,12 +51,14 @@ public final class ClaudeCodeAgentHandler extends AiAgentTypeHandler {
         if (config.isYoloMode()) {
             command.add("--dangerously-skip-permissions");
         }
-        String model = Util.fixEmptyAndTrim(config.getModel());
+        ModelSelection selection =
+                resolveModelSelection(config.getModel(), config.getReasoningEffort());
+        String model = Util.fixEmptyAndTrim(selection.getModel());
         if (model != null) {
             command.add("--model");
             command.add(model);
         }
-        String reasoningEffort = Util.fixEmptyAndTrim(config.getReasoningEffort());
+        String reasoningEffort = Util.fixEmptyAndTrim(selection.getReasoningEffort());
         if (reasoningEffort != null) {
             command.add("--effort");
             command.add(reasoningEffort);

--- a/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/codex/CodexAgentHandler.java
@@ -20,8 +20,12 @@ import org.kohsuke.stapler.DataBoundSetter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public final class CodexAgentHandler extends AiAgentTypeHandler {
+    private static final Set<String> REASONING_EFFORTS =
+            Set.of("low", "medium", "high", "xhigh", "max", "ultra");
+
     private boolean customConfigEnabled;
     private String customConfigToml = "";
     private String additionalGlobalArgs = "";
@@ -38,6 +42,11 @@ public final class CodexAgentHandler extends AiAgentTypeHandler {
     @Override
     public String getDefaultApiKeyEnvVar() {
         return "OPENAI_API_KEY";
+    }
+
+    @Override
+    protected Set<String> getSupportedReasoningEfforts() {
+        return REASONING_EFFORTS;
     }
 
     @Override
@@ -62,12 +71,14 @@ public final class CodexAgentHandler extends AiAgentTypeHandler {
             command.add("--ask-for-approval");
             command.add("never");
         }
-        String model = Util.fixEmptyAndTrim(config.getModel());
+        ModelSelection selection =
+                resolveModelSelection(config.getModel(), config.getReasoningEffort());
+        String model = Util.fixEmptyAndTrim(selection.getModel());
         if (model != null) {
             command.add("--model");
             command.add(model);
         }
-        String reasoningEffort = Util.fixEmptyAndTrim(config.getReasoningEffort());
+        String reasoningEffort = Util.fixEmptyAndTrim(selection.getReasoningEffort());
         if (reasoningEffort != null) {
             command.add("-c");
             command.add("model_reasoning_effort=" + tomlString(reasoningEffort));

--- a/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeAgentHandler.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/opencode/OpenCodeAgentHandler.java
@@ -18,8 +18,12 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 public final class OpenCodeAgentHandler extends AiAgentTypeHandler {
+    private static final Set<String> REASONING_EFFORTS =
+            Set.of("minimal", "low", "medium", "high", "xhigh", "max", "ultra");
+
     @DataBoundConstructor
     public OpenCodeAgentHandler() {}
 
@@ -39,18 +43,25 @@ public final class OpenCodeAgentHandler extends AiAgentTypeHandler {
     }
 
     @Override
+    protected Set<String> getSupportedReasoningEfforts() {
+        return REASONING_EFFORTS;
+    }
+
+    @Override
     public List<String> buildDefaultCommand(AiAgentConfiguration config, String prompt) {
         List<String> command = new ArrayList<>();
         command.add("opencode");
         command.add("run");
         command.add("--format");
         command.add("json");
-        String model = Util.fixEmptyAndTrim(config.getModel());
+        ModelSelection selection =
+                resolveModelSelection(config.getModel(), config.getReasoningEffort());
+        String model = Util.fixEmptyAndTrim(selection.getModel());
         if (model != null) {
             command.add("--model");
             command.add(model);
         }
-        String reasoningEffort = Util.fixEmptyAndTrim(config.getReasoningEffort());
+        String reasoningEffort = Util.fixEmptyAndTrim(selection.getReasoningEffort());
         if (reasoningEffort != null) {
             command.add("--variant");
             command.add(reasoningEffort);
@@ -65,8 +76,10 @@ public final class OpenCodeAgentHandler extends AiAgentTypeHandler {
         command.add("opencode");
         command.add("acp");
 
-        String model = Util.fixNull(config.getModel()).trim();
-        String reasoningEffort = Util.fixNull(config.getReasoningEffort()).trim();
+        ModelSelection selection =
+                resolveModelSelection(config.getModel(), config.getReasoningEffort());
+        String model = selection.getModel();
+        String reasoningEffort = selection.getReasoningEffort();
         List<String> extraArgs =
                 new ArrayList<>(Arrays.asList(Util.tokenize(Util.fixNull(config.getExtraArgs()))));
         for (int i = 0; i < extraArgs.size(); i++) {

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/config.jelly
@@ -6,11 +6,11 @@
     <f:textarea />
   </f:entry>
 
-  <f:entry title="Model (optional)" field="model">
+  <f:entry title="Model (optional)" field="model" description="Codex, Claude Code, and OpenCode accept model:effort shorthand, for example gpt-5.6-sol:xhigh. Use a double colon to keep a recognized suffix literal.">
     <f:textbox />
   </f:entry>
 
-  <f:entry title="Reasoning effort (optional)" field="reasoningEffort">
+  <f:entry title="Reasoning effort (optional)" field="reasoningEffort" description="Overrides any reasoning effort appended to the model name.">
     <f:textbox />
   </f:entry>
 

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-model.html
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-model.html
@@ -1,5 +1,10 @@
 <div>
   The model identifier to pass to the AI agent (for example
   <code>claude-sonnet-4</code>, <code>gpt-5.5</code>, <code>gemini-2.5-pro</code>).
+  For Codex, Claude Code, and OpenCode, append a recognized reasoning effort with a
+  colon, such as <code>gpt-5.6-sol:xhigh</code>. Other colon suffixes remain part of
+  the model identifier. Use a double colon to keep a recognized suffix literal, such
+  as <code>provider/model::high</code> for model <code>provider/model:high</code>. The
+  separate Reasoning effort field overrides the shorthand.
   Leave empty to use the agent's default model.
 </div>

--- a/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-reasoningEffort.html
+++ b/src/main/resources/io/jenkins/plugins/aiagentjob/AiAgentBuilder/help-reasoningEffort.html
@@ -3,5 +3,8 @@
   <code>model_reasoning_effort</code>, Claude Code maps it to <code>--effort</code>,
   and OpenCode maps it to <code>--variant</code>. Common values include
   <code>low</code>, <code>medium</code>, <code>high</code>, <code>xhigh</code>, and
-  <code>max</code>. Unsupported agents ignore this field.
+  <code>max</code>. Codex also supports <code>ultra</code> on compatible models, and
+  OpenCode supports <code>minimal</code>. You can instead append a recognized value to
+  the model, such as <code>gpt-5.6-sol:xhigh</code>. This field takes precedence over
+  that shorthand. Unsupported agents ignore this field.
 </div>

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
@@ -584,6 +584,50 @@ class AiAgentBuildExecutionTest {
 
     @Test
     @EnabledOnOs(OS.LINUX)
+    void expandsAndResolvesParameterizedModelReasoningSuffix(JenkinsRule jenkins) throws Exception {
+        File fakeBin =
+                installExecutable(
+                        jenkins,
+                        "fake-codex-suffix-bin",
+                        "codex",
+                        "#!/bin/sh\nprintf '%s\\n' \"$@\"\nprintf 'env-model=%s\\nenv-effort=%s\\n' \"$AI_AGENT_MODEL\" \"$AI_AGENT_REASONING_EFFORT\"\n");
+        String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-expanded-model-suffix",
+                        b -> {
+                            b.setAgent(new CodexAgentHandler());
+                            b.setPrompt("test");
+                            b.setModel("gpt-5.6-sol:${EFFORT_CHOICE}");
+                            b.setSetupScript("true");
+                            b.setEnvironmentVariables("PATH=" + path);
+                        });
+        project.addProperty(
+                new ParametersDefinitionProperty(
+                        new StringParameterDefinition("EFFORT_CHOICE", "xhigh")));
+
+        FreeStyleBuild build =
+                project.scheduleBuild2(
+                                0,
+                                new ParametersAction(
+                                        new StringParameterValue("EFFORT_CHOICE", "xhigh")))
+                        .get();
+        jenkins.assertBuildStatusSuccess(build);
+        AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
+        assertNotNull(action);
+        String rawLog = Files.readString(action.getRawLogFile().toPath());
+
+        assertTrue(rawLog.contains("gpt-5.6-sol"));
+        assertFalse(rawLog.contains("gpt-5.6-sol:xhigh"));
+        assertTrue(rawLog.contains("model_reasoning_effort=\"xhigh\""));
+        assertTrue(rawLog.contains("env-model=gpt-5.6-sol"));
+        assertTrue(rawLog.contains("env-effort=xhigh"));
+        assertEquals("gpt-5.6-sol", action.getInvocationModel(action.getLatestInvocationId()));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
     void executablePathRunsAgentOutsidePath(JenkinsRule jenkins) throws Exception {
         File fakeBin =
                 installExecutable(

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
@@ -713,6 +713,42 @@ class AiAgentBuildExecutionTest {
 
     @Test
     @EnabledOnOs(OS.LINUX)
+    void preservesEscapedReasoningSuffixDuringExecution(JenkinsRule jenkins) throws Exception {
+        File fakeBin =
+                installExecutable(
+                        jenkins,
+                        "fake-codex-escaped-suffix-bin",
+                        "codex",
+                        "#!/bin/sh\nprintf '%s\\n' \"$@\"\nprintf 'env-model=%s\\nenv-effort=%s\\n' \"$AI_AGENT_MODEL\" \"$AI_AGENT_REASONING_EFFORT\"\n");
+        String path = fakeBin.getAbsolutePath() + File.pathSeparator + System.getenv("PATH");
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-escaped-model-suffix",
+                        b -> {
+                            b.setAgent(new CodexAgentHandler());
+                            b.setPrompt("test");
+                            b.setModel("provider/example/model::high");
+                            b.setSetupScript("true");
+                            b.setEnvironmentVariables("PATH=" + path);
+                        });
+
+        FreeStyleBuild build = jenkins.buildAndAssertSuccess(project);
+        AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
+        assertNotNull(action);
+        String rawLog = Files.readString(action.getRawLogFile().toPath());
+
+        assertTrue(rawLog.contains("provider/example/model:high"));
+        assertFalse(rawLog.contains("model_reasoning_effort"));
+        assertTrue(rawLog.contains("env-model=provider/example/model:high"));
+        assertTrue(rawLog.contains("env-effort="));
+        assertEquals(
+                "provider/example/model:high",
+                action.getInvocationModel(action.getLatestInvocationId()));
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
     void processLaunchFailureCompletesInvocationMetadata(JenkinsRule jenkins) throws Exception {
         FreeStyleProject project =
                 newProject(
@@ -764,7 +800,7 @@ class AiAgentBuildExecutionTest {
                             b.setApprovalTimeoutSeconds(30);
                             b.setApiCredentialsId("approval-secret");
                             b.setApiEnvVarName("FAKE_ACP_SECRET_INPUT");
-                            b.setModel("test/provider-model");
+                            b.setModel("test/provider::high");
                             b.setExtraArgs("--variant high --format json --pure");
                             b.setExecutablePath(executable);
                             b.setSetupScript("cd \"${WORKSPACE}\"");
@@ -802,8 +838,7 @@ class AiAgentBuildExecutionTest {
                         .contains("\"optionId\":\"once\""));
         String configRequests = buildWorkspace.child("config-requests.jsonl").readToString();
         assertTrue(
-                configRequests.contains(
-                        "\"configId\":\"model\",\"value\":\"test/provider-model\""));
+                configRequests.contains("\"configId\":\"model\",\"value\":\"test/provider:high\""));
         assertTrue(configRequests.contains("\"configId\":\"effort\",\"value\":\"high\""));
         assertTrue(buildWorkspace.child("acp-command.txt").readToString().contains("acp --pure"));
 

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentCommandFactoryTest.java
@@ -108,6 +108,28 @@ class AiAgentCommandFactoryTest {
         assertEquals("xhigh", cmd.get(effortIdx + 1));
     }
 
+    @Test
+    void claudeCode_withModelReasoningSuffix() {
+        AiAgentBuilder project = createProject(new ClaudeCodeAgentHandler());
+        project.setModel("claude-opus-4:high");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        assertEquals("claude-opus-4", cmd.get(cmd.indexOf("--model") + 1));
+        assertEquals("high", cmd.get(cmd.indexOf("--effort") + 1));
+    }
+
+    @Test
+    void claudeCode_preservesUnsupportedReasoningSuffix() {
+        AiAgentBuilder project = createProject(new ClaudeCodeAgentHandler());
+        project.setModel("claude-opus-4:ultra");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        assertEquals("claude-opus-4:ultra", cmd.get(cmd.indexOf("--model") + 1));
+        assertFalse(cmd.contains("--effort"));
+    }
+
     // ======================== Codex Command Tests ========================
 
     @Test
@@ -197,6 +219,40 @@ class AiAgentCommandFactoryTest {
     }
 
     @Test
+    void codex_withModelReasoningSuffix() {
+        AiAgentBuilder project = createProject(new CodexAgentHandler());
+        project.setModel("gpt-5.6-sol:xhigh");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        assertEquals("gpt-5.6-sol", cmd.get(cmd.indexOf("--model") + 1));
+        assertEquals("model_reasoning_effort=\"xhigh\"", cmd.get(cmd.indexOf("-c") + 1));
+    }
+
+    @Test
+    void codex_reasoningFieldOverridesModelSuffix() {
+        AiAgentBuilder project = createProject(new CodexAgentHandler());
+        project.setModel("gpt-5.6-sol:xhigh");
+        project.setReasoningEffort("medium");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        assertEquals("gpt-5.6-sol", cmd.get(cmd.indexOf("--model") + 1));
+        assertEquals("model_reasoning_effort=\"medium\"", cmd.get(cmd.indexOf("-c") + 1));
+    }
+
+    @Test
+    void codex_preservesUnsupportedReasoningSuffix() {
+        AiAgentBuilder project = createProject(new CodexAgentHandler());
+        project.setModel("gpt-5.6-sol:minimal");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        assertEquals("gpt-5.6-sol:minimal", cmd.get(cmd.indexOf("--model") + 1));
+        assertFalse(cmd.contains("-c"));
+    }
+
+    @Test
     void codex_promptIsLastArgument() {
         AiAgentBuilder project = createProject(new CodexAgentHandler());
 
@@ -267,6 +323,16 @@ class AiAgentCommandFactoryTest {
     }
 
     @Test
+    void cursorAgent_preservesReasoningLikeModelSuffix() {
+        AiAgentBuilder project = createProject(new CursorAgentHandler());
+        project.setModel("cursor-model:high");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        assertEquals("cursor-model:high", cmd.get(cmd.indexOf("--model") + 1));
+    }
+
+    @Test
     void cursorAgent_manualApprovalsAreRejected() {
         AiAgentBuilder project = createProject(new CursorAgentHandler());
         project.setRequireApprovals(true);
@@ -319,6 +385,39 @@ class AiAgentCommandFactoryTest {
     }
 
     @Test
+    void openCode_withModelReasoningSuffix() {
+        AiAgentBuilder project = createProject(new OpenCodeAgentHandler());
+        project.setModel("openai/gpt-5.6-terra:ultra");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        assertEquals("openai/gpt-5.6-terra", cmd.get(cmd.indexOf("--model") + 1));
+        assertEquals("ultra", cmd.get(cmd.indexOf("--variant") + 1));
+    }
+
+    @Test
+    void openCode_preservesNonReasoningModelSuffix() {
+        AiAgentBuilder project = createProject(new OpenCodeAgentHandler());
+        project.setModel("openrouter/example/model:free");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        assertEquals("openrouter/example/model:free", cmd.get(cmd.indexOf("--model") + 1));
+        assertFalse(cmd.contains("--variant"));
+    }
+
+    @Test
+    void openCode_preservesEscapedReasoningLikeModelSuffix() {
+        AiAgentBuilder project = createProject(new OpenCodeAgentHandler());
+        project.setModel("provider/example/model::high");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        assertEquals("provider/example/model:high", cmd.get(cmd.indexOf("--model") + 1));
+        assertFalse(cmd.contains("--variant"));
+    }
+
+    @Test
     void openCode_acpExecutionMapsRunOptionsToSessionConfig() {
         OpenCodeAgentHandler handler = new OpenCodeAgentHandler();
         AiAgentBuilder project = createProject(handler);
@@ -334,6 +433,18 @@ class AiAgentCommandFactoryTest {
                 AiAgentCommandFactory.applyExecutablePath(
                         execution.getCommand(), project.getExecutablePath()));
         assertEquals("override/model", execution.getModel());
+        assertEquals("xhigh", execution.getReasoningEffort());
+    }
+
+    @Test
+    void openCode_acpExecutionMapsModelReasoningSuffixToSessionConfig() {
+        OpenCodeAgentHandler handler = new OpenCodeAgentHandler();
+        AiAgentBuilder project = createProject(handler);
+        project.setModel("openai/gpt-5.6-sol:xhigh");
+
+        AiAgentTypeHandler.AcpExecutionSpec execution = handler.buildAcpExecution(project);
+
+        assertEquals("openai/gpt-5.6-sol", execution.getModel());
         assertEquals("xhigh", execution.getReasoningEffort());
     }
 
@@ -399,6 +510,16 @@ class AiAgentCommandFactoryTest {
         int modelIdx = cmd.indexOf("-m");
         assertTrue(modelIdx >= 0, "Should have -m");
         assertEquals("gemini-2.5-flash", cmd.get(modelIdx + 1));
+    }
+
+    @Test
+    void geminiCli_preservesReasoningLikeModelSuffix() {
+        AiAgentBuilder project = createProject(new GeminiCliAgentHandler());
+        project.setModel("gemini-model:high");
+
+        List<String> cmd = AiAgentCommandFactory.buildDefaultCommand(project, "test");
+
+        assertEquals("gemini-model:high", cmd.get(cmd.indexOf("-m") + 1));
     }
 
     // ======================== Extra Args Tests ========================


### PR DESCRIPTION
## Summary

Add `model:effort` shorthand for agents with native reasoning-effort controls. This makes values such as `gpt-5.6-sol:xhigh` usable directly from the Model field while retaining the separate Reasoning effort field.

## Changes

- Resolve recognized effort suffixes after Jenkins environment expansion.
- Use agent-specific suffix sets for Codex, Claude Code, and OpenCode, including OpenCode ACP.
- Let the explicit Reasoning effort field override the suffix.
- Preserve unknown suffixes and unsupported-agent model values unchanged.
- Support `::` as an escape for literal recognized suffixes, such as `provider/model::high`.
- Document syntax, precedence, and `extraArgs` metadata behavior in form help and README.

## Testing

- `mvn -B -ntp clean verify` (229 tests, 0 failures, 1 skipped; HPI, SpotBugs, and formatter clean)
- focused merged execution/command suite (53 tests)
- `npm test` (7 tests)
- independent post-fix review: PASS
- verified current local CLI help for Codex 0.145.0, Claude Code 2.1.145, and OpenCode

## Did this cause any problems?

Rollback by reverting these commits and rebuilding the plugin.