### PR TITLE
[core] Close stdin for Kubernetes agents

### DIFF
--- a/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
+++ b/src/main/java/io/jenkins/plugins/aiagentjob/AiAgentExecutor.java
@@ -170,19 +170,37 @@ final class AiAgentExecutor {
                                 acpExecution == null
                                         ? List.of()
                                         : acpExecution.getAuthenticationMethods().keySet(),
-                                acpExecution != null);
+                                acpExecution != null,
+                                disableInteractive);
                 tempSetupScript = writeTempScript(workspace, combinedScript);
                 command = buildShellCommand(combinedScript, tempSetupScript);
                 waitForAcpProcessReady = acpExecution != null;
             } else if (!commandOverride.isEmpty()) {
                 if (launcher.isUnix()) {
                     // Use a non-login shell so injected HOME/USERPROFILE are not overridden.
-                    command = List.of("/bin/sh", "-c", commandOverride);
+                    command =
+                            List.of(
+                                    "/bin/sh",
+                                    "-c",
+                                    disableInteractive
+                                            ? closeStdinInShell(commandOverride)
+                                            : commandOverride);
                 } else {
-                    command = List.of("cmd", "/c", commandOverride);
+                    command =
+                            List.of(
+                                    "cmd",
+                                    "/c",
+                                    disableInteractive
+                                            ? "(" + commandOverride + ") < NUL"
+                                            : commandOverride);
                 }
             } else if (!launcher.isUnix()) {
-                command = buildWindowsCommand(agentCommand);
+                command = buildWindowsCommand(agentCommand, disableInteractive);
+            } else if (disableInteractive) {
+                String nonInteractiveScript =
+                        buildCombinedScript("", Map.of(), agentCommand, "", List.of(), false, true);
+                tempSetupScript = writeTempScript(workspace, nonInteractiveScript);
+                command = buildShellCommand(nonInteractiveScript, tempSetupScript);
             } else {
                 command = agentCommand;
             }
@@ -249,7 +267,7 @@ final class AiAgentExecutor {
                                         .stderr(stderrSink)
                                         .quiet(true);
                         if (disableInteractive) {
-                            procStarter.stdin(InputStream.nullInputStream());
+                            procStarter.stdin(null);
                         }
                         Proc proc = startProcess(procStarter, command.get(0));
                         outputHandler.attach(proc);
@@ -445,7 +463,8 @@ final class AiAgentExecutor {
             List<String> agentCommand,
             String commandOverride,
             Iterable<String> acpAuthenticationEnvironmentVariables,
-            boolean acpMode) {
+            boolean acpMode,
+            boolean disableInteractive) {
         StringBuilder sb = new StringBuilder();
         appendShebangAwarePreamble(sb, setupScript, shellEnvironment);
         sb.append("set +x\n");
@@ -453,6 +472,9 @@ final class AiAgentExecutor {
             sb.append("printf '\\n'\n");
         }
         appendAcpAuthenticationMarkers(sb, acpAuthenticationEnvironmentVariables);
+        if (disableInteractive) {
+            sb.append("exec < /dev/null\n");
+        }
         if (!commandOverride.isEmpty()) {
             if (acpMode) {
                 appendAcpProcessReadyMarker(sb);
@@ -474,6 +496,10 @@ final class AiAgentExecutor {
             sb.append('\n');
         }
         return sb.toString();
+    }
+
+    private static String closeStdinInShell(String command) {
+        return "exec < /dev/null\n" + command;
     }
 
     private static void appendExecutableCheck(StringBuilder sb, String executable) {
@@ -598,7 +624,17 @@ final class AiAgentExecutor {
     }
 
     static List<String> buildWindowsCommand(List<String> command) {
-        return new ArgumentListBuilder().add(command).toWindowsCommand(true).toList();
+        return buildWindowsCommand(command, false);
+    }
+
+    static List<String> buildWindowsCommand(List<String> command, boolean disableInteractive) {
+        List<String> windowsCommand =
+                new ArrayList<>(
+                        new ArgumentListBuilder().add(command).toWindowsCommand(true).toList());
+        if (disableInteractive) {
+            windowsCommand.add(windowsCommand.size() - 3, "<NUL");
+        }
+        return windowsCommand;
     }
 
     private static FilePath resolveRunDirectory(FilePath workspace, String workDirValue) {

--- a/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
+++ b/src/test/java/io/jenkins/plugins/aiagentjob/AiAgentBuildExecutionTest.java
@@ -9,10 +9,16 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.domains.Domain;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+
 import hudson.FilePath;
+import hudson.Launcher;
+import hudson.LauncherDecorator;
+import hudson.Proc;
 import hudson.model.Executor;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
+import hudson.model.Node;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Result;
@@ -37,11 +43,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
@@ -122,6 +131,82 @@ class AiAgentBuildExecutionTest {
         assertNotNull(action);
         assertFalse(action.getEvents().isEmpty());
         assertTrue(action.getRawLogFile().exists());
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX)
+    void disableInteractive_closesCommandStdin(JenkinsRule jenkins) throws Exception {
+        File fakeBin =
+                installExecutable(
+                        jenkins,
+                        "stdin-codex-bin",
+                        "stdin-codex",
+                        "#!/bin/sh\n"
+                                + "[ \"$1\" = \"--sandbox\" ] || exit 92\n"
+                                + "if IFS= read -r unexpected; then exit 91; fi\n"
+                                + "echo '{\"type\":\"item.completed\",\"item\":{\"type\":"
+                                + "\"agent_message\",\"text\":\"stdin closed\"}}'\n");
+        FreeStyleProject project =
+                newProject(
+                        jenkins,
+                        "ai-build-stdin-closed",
+                        b -> {
+                            b.setAgent(new CodexAgentHandler());
+                            b.setPrompt("hello");
+                            b.setExecutablePath(new File(fakeBin, "stdin-codex").getAbsolutePath());
+                            b.setDisableInteractive(true);
+                            b.setFailOnAgentError(true);
+                        });
+
+        QueueTaskFuture<FreeStyleBuild> future = project.scheduleBuild2(0);
+        assertNotNull(future);
+        try {
+            FreeStyleBuild build = future.get(10, TimeUnit.SECONDS);
+            jenkins.assertBuildStatusSuccess(build);
+            AiAgentRunAction action = build.getAction(AiAgentRunAction.class);
+            assertNotNull(action);
+            assertTrue(Files.readString(action.getRawLogFile().toPath()).contains("stdin closed"));
+        } finally {
+            OpenStdinLauncherDecorator.closeInput();
+            if (!future.isDone()) {
+                future.cancel(true);
+            }
+        }
+    }
+
+    @TestExtension("disableInteractive_closesCommandStdin")
+    public static final class OpenStdinLauncherDecorator extends LauncherDecorator {
+        private static volatile PipedOutputStream openInput;
+
+        @NonNull
+        @Override
+        public Launcher decorate(@NonNull Launcher launcher, @NonNull Node node) {
+            return new Launcher.DecoratedLauncher(launcher) {
+                @Override
+                public Proc launch(ProcStarter starter) throws IOException {
+                    PipedOutputStream input = new PipedOutputStream();
+                    openInput = input;
+                    StringBuilder command = new StringBuilder();
+                    for (String argument : starter.cmds()) {
+                        if (!command.isEmpty()) {
+                            command.append(' ');
+                        }
+                        command.append('"').append(argument.replace("\"", "\\\"")).append('"');
+                    }
+                    return getInner()
+                            .launch(
+                                    starter.cmds(List.of("/bin/sh", "-c", command.toString()))
+                                            .stdin(new PipedInputStream(input)));
+                }
+            };
+        }
+
+        static void closeInput() throws IOException {
+            if (openInput != null) {
+                openInput.close();
+                openInput = null;
+            }
+        }
     }
 
     @Test
@@ -479,6 +564,10 @@ class AiAgentBuildExecutionTest {
         assertTrue(commandLine.contains("prompt with spaces"));
         assertFalse(commandLine.contains("%OPENAI_API_KEY%"));
         assertTrue(commandLine.contains("100% literal"));
+
+        List<String> nonInteractiveCommand =
+                AiAgentExecutor.buildWindowsCommand(List.of("codex", "exec", "prompt"), true);
+        assertEquals("<NUL", nonInteractiveCommand.get(nonInteractiveCommand.size() - 4));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Restore command-level stdin closure for non-ACP jobs when Disable interactive mode is enabled. Kubernetes launcher decorators keep persistent exec input open and ignore `ProcStarter` stdin, leaving agent commands waiting indefinitely.

## Changes

- redirect Unix agent commands from `/dev/null` through an agent-local script with quoted command tokens
- close stdin for Unix and Windows command overrides and generated Windows commands
- preserve ACP protocol stdin
- reproduce Kubernetes outer-shell command serialization and persistent stdin in regression coverage

## Reproduction

Configure a Kubernetes-backed job with `disableInteractive: true` and built-in agent command generation. Before this change, agent waits for stdin; a command override with `< /dev/null` succeeds.

Fixes #44

## Testing

- `mvn -B -ntp clean verify` (273 tests, 1 skipped)
- `npm ci --ignore-scripts`
- `npm test` (8 tests)
- regression path fails before fix by timing out and passes after fix

## Did this cause any problems?

Revert this commit and redeploy plugin.